### PR TITLE
chore: enable dependabot (auto-generated)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,18 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-  
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule: { interval: "daily", time: "04:00" }
+    open-pull-requests-limit: 10
+    labels: ["dependencies", "github-actions"]
+    groups:
+      actions:
+        patterns: ["*"]
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule: { interval: "daily", time: "04:15" }
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "docker"]
+    groups:
+      docker-images:
+        patterns: ["*"]


### PR DESCRIPTION
This PR adds a dependabot.yml generated by a script.

- Detects ecosystems present in repo
- Enables daily checks + grouping
- Avoids enabling ecosystems that do not exist
