### PR TITLE
chore: enable dependabot (daily, min PRs)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,16 +3,18 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule: { interval: "daily", time: "04:00" }
-    open-pull-requests-limit: 10
-    labels: ["dependencies", "github-actions"]
+    open-pull-requests-limit: 1
+    rebase-strategy: "auto"
+    labels: ["dependencies","github-actions"]
     groups:
-      actions:
+      all:
         patterns: ["*"]
   - package-ecosystem: "docker"
     directory: "/"
     schedule: { interval: "daily", time: "04:15" }
-    open-pull-requests-limit: 5
-    labels: ["dependencies", "docker"]
+    open-pull-requests-limit: 1
+    rebase-strategy: "auto"
+    labels: ["dependencies","docker"]
     groups:
-      docker-images:
+      all:
         patterns: ["*"]


### PR DESCRIPTION
This PR adds dependabot configuration optimized for low noise.

- Daily checks
- Group updates to minimize PR count
- Open PR limit per ecosystem = 1
- Prefer automatic rebase when conflicts happen
