### PR TITLE
fix(proxy): enforce outbound egress policy

### DIFF
--- a/.github/workflows/proxy-egress-integration.yml
+++ b/.github/workflows/proxy-egress-integration.yml
@@ -1,0 +1,39 @@
+name: Proxy egress integration
+
+on:
+  pull_request:
+    branches: [dev, master]
+    paths:
+      - 'src/handler/**'
+      - 'src/generator/**'
+      - 'src/script/**'
+      - 'src/utils/**'
+      - 'tests/proxy_egress_integration.py'
+      - 'tests/proxy_policy_test.cpp'
+      - 'CMakeLists.txt'
+      - 'Dockerfile'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  docker-proxy-egress:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build and run policy unit tests in the official Docker builder
+        run: docker build --target builder --build-arg BUILD_TESTS=true .
+      - name: Build the official Dockerfile
+        run: docker build --pull --tag sce-proxy-egress:${{ github.sha }} .
+      - name: Verify final-image CA bundle
+        run: |
+          docker run --rm --entrypoint sh sce-proxy-egress:${{ github.sha }} -ec '
+            test -s /etc/ssl/cert.pem || test -s /etc/ssl/certs/ca-certificates.crt
+            ls -l /etc/ssl/cert.pem /etc/ssl/certs/ca-certificates.crt 2>/dev/null || true
+          '
+      - name: Verify policy unit tests and Docker SOCKS5 egress
+        run: |
+          set -euo pipefail
+          python3 tests/proxy_egress_integration.py --image sce-proxy-egress:${{ github.sha }}

--- a/.github/workflows/proxy-egress-integration.yml
+++ b/.github/workflows/proxy-egress-integration.yml
@@ -23,6 +23,12 @@ jobs:
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@v6
+      - name: Fetch pinned Custom_OpenClash_Rules test assets
+        run: |
+          set -euo pipefail
+          ref="$(python3 -c "import json; print(json.load(open('scripts/ci/dependencies.lock.json'))['git']['custom_openclash_rules']['revision'])")"
+          python3 scripts/sync_custom_openclash_rules.py --ref "$ref"
+          test -s base/Custom_OpenClash_Rules/manifest.sha256
       - name: Build and run policy unit tests in the official Docker builder
         run: docker build --target builder --build-arg BUILD_TESTS=true .
       - name: Build the official Dockerfile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ ADD_EXECUTABLE(${BUILD_TARGET_NAME}
     src/handler/upload.cpp
     src/handler/version_page.cpp
     src/handler/webget.cpp
+    src/handler/proxy_policy.cpp
     src/handler/settings.cpp
     src/main.cpp
     src/parser/infoparser.cpp
@@ -99,6 +100,7 @@ ADD_EXECUTABLE(${BUILD_TARGET_NAME}
     src/utils/logger.cpp
     src/utils/md5/md5.cpp
     src/utils/network.cpp
+    src/utils/redact.cpp
     src/utils/regexp.cpp
     src/utils/string.cpp
     src/utils/system.cpp
@@ -216,6 +218,16 @@ ENDIF()
 
 IF(BUILD_TESTS)
     ENABLE_TESTING()
+    ADD_EXECUTABLE(proxy_policy_test
+        tests/proxy_policy_test.cpp
+        src/handler/proxy_policy.cpp
+        src/utils/redact.cpp
+        src/utils/string.cpp
+        src/utils/system.cpp)
+    TARGET_INCLUDE_DIRECTORIES(proxy_policy_test PRIVATE src)
+    TARGET_LINK_LIBRARIES(proxy_policy_test ${CMAKE_THREAD_LIBS_INIT})
+    ADD_TEST(NAME proxy_policy COMMAND proxy_policy_test)
+
     ADD_EXECUTABLE(custom_openclash_rules_test
         tests/custom_openclash_rules_test.cpp
         src/config/custom_openclash_rules.cpp

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,7 @@ ARG CPP_HTTPLIB_REF
 ARG NLOHMANN_JSON_REF
 ARG INJA_REF
 ARG JPCRE2_REF
+ARG BUILD_TESTS=false
 
 WORKDIR /
 
@@ -180,11 +181,14 @@ RUN set -xe && \
     export CCACHE_COMPILERCHECK=content && \
     cmake -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_TESTS=${BUILD_TESTS} \
     -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
     -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF \
     -DCMAKE_POSITION_INDEPENDENT_CODE=OFF \
     . && \
     ninja -j ${THREADS}
+
+RUN if [ "${BUILD_TESTS}" = "true" ]; then ctest --output-on-failure; fi
 
 # 收集 glibc 运行时依赖（动态探测，避免固定版本）
 RUN set -xe && \

--- a/base/pref.example.ini
+++ b/base/pref.example.ini
@@ -68,10 +68,10 @@ sssub_rule_base=base/all_base.tpl
 ;sing-box 基础模板。/ sing-box base template.
 singbox_rule_base=base/all_base.tpl
 
-;分别控制下载外部配置、规则集和订阅时使用的代理。SYSTEM 使用系统代理，NONE 或空值直连；支持 cURL 的 http/https/socks4a/socks5 URL。
-;Proxies used when downloading external configs, rulesets, and subscriptions respectively. SYSTEM uses the system proxy; NONE or empty connects directly; cURL http/https/socks4a/socks5 URLs are supported.
-;CORS 代理地址可加 cors: 前缀，例如 cors:https://cors-anywhere.example/。
-;Prefix a CORS proxy with cors:, for example cors:https://cors-anywhere.example/.
+;分别控制下载外部配置、规则集和订阅时使用的代理。NONE（不区分大小写）和空值强制直连并忽略环境代理；SYSTEM 按系统代理来源解析；显式 http/https/socks4/socks4a/socks5/socks5h URI 不会被 NO_PROXY 绕过。
+;Proxies used when downloading external configs, rulesets, and subscriptions. NONE (case-insensitive) and empty force direct connections and ignore proxy environment variables. SYSTEM resolves the documented system source. Explicit http/https/socks4/socks4a/socks5/socks5h URIs are never bypassed by NO_PROXY.
+;socks5 本地解析域名，socks5h 由 SOCKS 服务端解析。cors:https://relay.example/ 是兼容的 HTTP CORS 中继，而不是网络代理。
+;socks5 resolves names locally; socks5h lets the SOCKS server resolve them. cors:https://relay.example/ is a compatible HTTP CORS relay, not a network proxy.
 proxy_config=SYSTEM
 proxy_ruleset=SYSTEM
 proxy_subscription=NONE
@@ -412,6 +412,9 @@ enable_request_coalescing=true
 ;合并请求首次得到 5xx 时是否在服务端内部重试一次；SUBCONVERTER_COALESCE_RETRY_ON_5XX 可覆盖。
 ;Whether a coalesced request performs one internal retry after an initial 5xx; SUBCONVERTER_COALESCE_RETRY_ON_5XX overrides it.
 coalesce_retry_on_5xx=true
+;默认验证远程 TLS 证书。仅在受控兼容场景临时设为 true；不要把它作为网络错误的常规修复手段。
+;Remote TLS certificates are verified by default. Set true only as a temporary, controlled compatibility exception; do not use it as a routine response to network errors.
+allow_insecure_tls=false
 ;符合请求合并条件且未启用 Age 加密的 200 /sub 响应微缓存秒数；0 关闭，正值最大收敛为 5。SUBCONVERTER_RESPONSE_CACHE_TTL 可覆盖。
 ;Micro-cache seconds for eligible coalesced, non-Age-encrypted 200 /sub responses; 0 disables it and values are capped at 5. SUBCONVERTER_RESPONSE_CACHE_TTL overrides it.
 response_cache_ttl=0

--- a/base/pref.example.toml
+++ b/base/pref.example.toml
@@ -77,8 +77,10 @@ sssub_rule_base = "base/all_base.tpl"
 # sing-box 基础模板。/ sing-box base template.
 singbox_rule_base = "base/all_base.tpl"
 
-# 分别控制下载外部配置、规则集和订阅时使用的代理。SYSTEM 使用系统代理，NONE 或空值直连，也支持 http/https/socks4a/socks5 URL。
-# Proxies used when downloading external configs, rulesets, and subscriptions respectively. SYSTEM uses the system proxy; NONE or empty connects directly; http/https/socks4a/socks5 URLs are supported.
+# 分别控制下载外部配置、规则集和订阅时使用的代理。NONE（不区分大小写）和空值强制直连并忽略环境代理；SYSTEM 按系统代理来源解析；显式 URI 支持 http/https/socks4/socks4a/socks5/socks5h，且不会被 NO_PROXY 绕过。
+# Proxies used when downloading external configs, rulesets, and subscriptions. NONE (case-insensitive) and an empty value force direct connections and ignore proxy environment variables. SYSTEM resolves the documented system source. Explicit http/https/socks4/socks4a/socks5/socks5h URIs are never bypassed by NO_PROXY.
+# socks5 在本地解析域名，socks5h 将域名交给 SOCKS 服务端解析。cors:https://relay.example/ 是兼容的 HTTP CORS 中继，不是底层网络代理。
+# socks5 resolves names locally; socks5h lets the SOCKS server resolve them. cors:https://relay.example/ is a compatible HTTP CORS relay, not a network proxy.
 proxy_config = "SYSTEM"
 proxy_ruleset = "SYSTEM"
 proxy_subscription = "NONE"
@@ -492,6 +494,9 @@ enable_request_coalescing = true
 # 合并请求首次得到 5xx 时是否在服务端内部重试一次；SUBCONVERTER_COALESCE_RETRY_ON_5XX 可覆盖。
 # Whether a coalesced request performs one internal retry after an initial 5xx; SUBCONVERTER_COALESCE_RETRY_ON_5XX overrides it.
 coalesce_retry_on_5xx = true
+# 默认验证远程 TLS 证书。仅在受控兼容场景临时设为 true；不要把它作为网络错误的常规修复手段。
+# Remote TLS certificates are verified by default. Set true only as a temporary, controlled compatibility exception; do not use it as a routine response to network errors.
+allow_insecure_tls = false
 # 符合请求合并条件且未启用 Age 加密的 200 /sub 响应微缓存秒数；0 关闭，正值最大收敛为 5。SUBCONVERTER_RESPONSE_CACHE_TTL 可覆盖。
 # Micro-cache seconds for eligible coalesced, non-Age-encrypted 200 /sub responses; 0 disables it and values are capped at 5. SUBCONVERTER_RESPONSE_CACHE_TTL overrides it.
 response_cache_ttl = 0

--- a/base/pref.example.yml
+++ b/base/pref.example.yml
@@ -42,8 +42,10 @@ common:
   loon_rule_base: base/all_base.tpl
   sssub_rule_base: base/all_base.tpl
   singbox_rule_base: base/all_base.tpl
-  # 分别控制下载外部配置、规则集和订阅时使用的代理。SYSTEM 使用系统代理，NONE 或空值直连，也支持 http/https/socks4a/socks5 URL。
-  # Proxies used when downloading external configs, rulesets, and subscriptions respectively. SYSTEM uses the system proxy; NONE or an empty value connects directly; http/https/socks4a/socks5 URLs are supported.
+  # 分别控制下载外部配置、规则集和订阅时使用的代理。NONE（不区分大小写）和空值强制直连并忽略环境代理；SYSTEM 按系统代理来源解析；显式 http/https/socks4/socks4a/socks5/socks5h URI 不会被 NO_PROXY 绕过。
+  # Proxies used when downloading external configs, rulesets, and subscriptions. NONE (case-insensitive) and an empty value force direct connections and ignore proxy environment variables. SYSTEM resolves the documented system source. Explicit http/https/socks4/socks4a/socks5/socks5h URIs are never bypassed by NO_PROXY.
+  # socks5 本地解析域名，socks5h 由 SOCKS 服务端解析。cors:https://relay.example/ 是兼容的 HTTP CORS 中继，而不是网络代理。
+  # socks5 resolves names locally; socks5h lets the SOCKS server resolve them. cors:https://relay.example/ is a compatible HTTP CORS relay, not a network proxy.
   proxy_config: SYSTEM
   proxy_ruleset: SYSTEM
   proxy_subscription: NONE
@@ -344,6 +346,9 @@ advanced:
   # 合并请求首次得到 5xx 时是否在服务端内部重试一次；SUBCONVERTER_COALESCE_RETRY_ON_5XX 可覆盖。
   # Whether a coalesced request performs one internal retry after an initial 5xx; SUBCONVERTER_COALESCE_RETRY_ON_5XX overrides it.
   coalesce_retry_on_5xx: true
+  # 默认验证远程 TLS 证书。仅在受控兼容场景临时设为 true；不要把它作为网络错误的常规修复手段。
+  # Remote TLS certificates are verified by default. Set true only as a temporary, controlled compatibility exception; do not use it as a routine response to network errors.
+  allow_insecure_tls: false
   # 符合请求合并条件且未启用 Age 加密的 200 /sub 响应微缓存秒数；0 关闭，正值最大收敛为 5。SUBCONVERTER_RESPONSE_CACHE_TTL 可覆盖。
   # Micro-cache seconds for eligible coalesced, non-Age-encrypted 200 /sub responses; 0 disables it and values are capped at 5. SUBCONVERTER_RESPONSE_CACHE_TTL overrides it.
   response_cache_ttl: 0

--- a/docs/outbound-proxy.md
+++ b/docs/outbound-proxy.md
@@ -1,0 +1,67 @@
+# Outbound proxy policy
+
+`proxy_config`, `proxy_ruleset`, and `proxy_subscription` use a deliberate
+outbound policy rather than a truthy proxy string. Leading and trailing
+whitespace is ignored.
+
+| Value | Policy | Effect |
+| --- | --- | --- |
+| empty or `NONE` | Direct | Explicitly disables libcurl proxy environment variables for that request. `NONE` is case-insensitive. |
+| `SYSTEM` | System | Resolves the platform system proxy. On Unix-like systems the first present value is `all_proxy`, `ALL_PROXY`, `http_proxy`, `HTTP_PROXY`, `https_proxy`, then `HTTPS_PROXY`; `NO_PROXY`/`no_proxy` is respected. Windows uses enabled Internet Settings proxy data. |
+| `http://…`, `https://…`, `socks4://…`, `socks4a://…`, `socks5://…`, `socks5h://…` | Explicit | Uses that proxy only. `NO_PROXY` and `no_proxy` cannot bypass it, so a failed explicit proxy fails closed instead of retrying direct. URI validation requires a supported scheme, host, and port. |
+| `cors:https://…` | Cors | Compatibility HTTP CORS relay. It prefixes the requested URL and is transported directly; it is not a libcurl proxy. |
+
+Malformed non-empty policies are rejected. They never become direct requests.
+
+## Which setting applies
+
+- `proxy_config`: external configurations, remote base templates, in-template
+  `fetch`, cron scripts, QuickJS `fetch` without `proxy`, GeoIP helper calls,
+  and Gist/auxiliary API requests.
+- `proxy_ruleset`: downloaded and converted rulesets.
+- `proxy_subscription`: backend expansion/download of a subscription, such as
+  `list=true` or a non-Clash output.
+
+QuickJS `fetch({url})` inherits `proxy_config`. An own `proxy` property may
+override it with `NONE`, `SYSTEM`, or an explicit URI. An empty own value is
+Direct, not inherited.
+
+For a default Clash Proxy-Provider request, SubConverter-Extended emits a
+provider URL and does **not** download the subscription itself. Mihomo later
+downloads it, so this process's `proxy_subscription` cannot govern that
+client-side refresh. This is intentional.
+
+## DNS, security, and deployment boundaries
+
+`socks5://` asks libcurl to resolve a hostname locally before connecting to the
+SOCKS server. `socks5h://` sends the hostname to the SOCKS server for remote
+resolution. Remote resolution does not weaken the public-request SSRF checks:
+literal/private and locally resolved private destinations remain denied under
+the public profile. A proxy-resolved address that cannot be observed locally is
+an unavoidable limit; do not rely on `socks5h` alone to enforce an SSRF allow
+list.
+
+Application policy controls this program's libcurl traffic. It cannot prove
+that other processes, DNS resolvers, client-side Proxy-Provider refreshes, or
+the host network will never use a native route. Deployments that must prohibit
+all native IP egress need firewall/routing/namespace egress controls in
+addition to this setting.
+
+Remote TLS certificate and hostname verification are enabled by default. The
+`advanced.allow_insecure_tls` migration escape hatch is off by default and
+should be removed again after a controlled compatibility investigation; it is
+not a retry or fallback mechanism.
+
+For idempotent GET/HEAD transfers only, one 200 ms retry is made after a
+recoverable DNS/connect/timeout/send/receive/partial-transfer error. It never
+retries authentication failures, TLS verification failures, policy/security
+rejections, malformed URLs, HTTP status responses, POST, or PATCH; a retry
+therefore cannot turn an explicit-proxy failure into a direct request.
+
+## Diagnostics and secrets
+
+Verbose logs report `Direct`, `System`, `Explicit`, or `Cors`, a redacted
+scheme/host/port, whether supported libcurl can confirm proxy use, and a broad
+error category. `/sub?...&explain=true` exposes the same redacted policy
+summary. Proxy user information, credentials, authorization headers, and
+common token-like URL query values are redacted before logging.

--- a/src/generator/config/nodemanip.cpp
+++ b/src/generator/config/nodemanip.cpp
@@ -96,7 +96,8 @@ static bool isBrowserUA(const std::string &ua) {
 
 int addNodes(std::string link, std::vector<Proxy> &allNodes, int groupID,
              parse_settings &parse_set) {
-  std::string &proxy = *parse_set.proxy, &subInfo = *parse_set.sub_info;
+  ProxyPolicy &proxy = *parse_set.proxy;
+  std::string &subInfo = *parse_set.sub_info;
   string_array &exclude_remarks = *parse_set.exclude_remarks;
   string_array &include_remarks = *parse_set.include_remarks;
   RegexMatchConfigs &stream_rules = *parse_set.stream_rules;

--- a/src/generator/config/nodemanip.h
+++ b/src/generator/config/nodemanip.h
@@ -11,13 +11,14 @@
 
 #include "config/regmatch.h"
 #include "handler/fetch_context.h"
+#include "handler/proxy_policy.h"
 #include "parser/config/proxy.h"
 #include "utils/map_extra.h"
 #include "utils/string.h"
 
 struct parse_settings
 {
-    std::string *proxy = nullptr;
+    ProxyPolicy *proxy = nullptr;
     string_array *exclude_remarks = nullptr;
     string_array *include_remarks = nullptr;
     RegexMatchConfigs *stream_rules = nullptr;

--- a/src/generator/template/templates.cpp
+++ b/src/generator/template/templates.cpp
@@ -118,7 +118,8 @@ std::string parseHostname(inja::Arguments &args)
     if(!urls.size())
         return std::string();
 
-    std::string input_content, output_content, proxy = parseProxy(global.proxyConfig);
+    std::string input_content, output_content;
+    ProxyPolicy proxy = parseProxy(global.proxyConfig);
     for(std::string &x : urls)
     {
         input_content = webGet(x, proxy, global.cacheConfig);
@@ -143,7 +144,8 @@ std::string parseHostname(inja::Arguments &args)
 #ifndef NO_WEBGET
 std::string template_webGet(inja::Arguments &args)
 {
-    std::string data = args.at(0)->get<std::string>(), proxy = parseProxy(global.proxyConfig);
+    std::string data = args.at(0)->get<std::string>();
+    ProxyPolicy proxy = parseProxy(global.proxyConfig);
     writeLog(0, "模板调用 fetch，URL：'" + data + "'。", LOG_LEVEL_INFO);
     return webGet(data, proxy, global.cacheConfig, nullptr, nullptr,
                   current_template_fetch_context);

--- a/src/handler/interfaces.cpp
+++ b/src/handler/interfaces.cpp
@@ -294,15 +294,6 @@ static void appendVaryHeader(Response &response, const std::string &field) {
   iter->second += ", " + field;
 }
 
-std::string parseProxy(const std::string &source) {
-  std::string proxy = source;
-  if (source == "SYSTEM")
-    proxy = getSystemProxy();
-  else if (source == "NONE")
-    proxy = "";
-  return proxy;
-}
-
 static std::string buildProviderRemarkFilter(const string_array &rules) {
   string_array valid_rules;
   for (const std::string &rule : rules) {
@@ -940,6 +931,9 @@ struct SubExplainReport {
   bool proxy_provider_mode = false;
   bool nodelist = false;
   bool managed_config = false;
+  std::string proxy_config;
+  std::string proxy_ruleset;
+  std::string proxy_subscription;
   std::string base_fetch_context = "trusted_config";
   std::string ruleset_fetch_context = "trusted_config";
   size_t raw_url_count = 0;
@@ -1113,6 +1107,13 @@ static std::string serializeSubExplainReport(const SubExplainReport &report,
        report.effective_config_sections)
     writeExplainConfigSection(writer, section);
   writer.EndArray();
+  writer.EndObject();
+
+  writer.Key("outbound_proxy");
+  writer.StartObject();
+  writeJsonString(writer, "config", report.proxy_config);
+  writeJsonString(writer, "ruleset", report.proxy_ruleset);
+  writeJsonString(writer, "subscription", report.proxy_subscription);
   writer.EndObject();
 
   writer.Key("resources");
@@ -1574,6 +1575,9 @@ static std::string subconverter_impl(Request &request, Response &response,
   bool explainMode = isTruthyRequestValue(getUrlArg(argument, "explain"));
   SubExplainReport explain;
   explain.enabled = explainMode;
+  explain.proxy_config = parseProxy(global.proxyConfig).describe();
+  explain.proxy_ruleset = parseProxy(global.proxyRuleset).describe();
+  explain.proxy_subscription = parseProxy(global.proxySubscription).describe();
   explain.requested_target = argTarget;
   if (explainMode) {
     std::string rawUrlForLog = getUrlArg(argument, "url");
@@ -1775,7 +1779,7 @@ static std::string subconverter_impl(Request &request, Response &response,
   tpl_args.request_params = std::move(req_arg_map);
 
   /// check for proxy settings
-  std::string proxy = parseProxy(global.proxySubscription);
+  ProxyPolicy proxy = parseProxy(global.proxySubscription);
 
   /// check other flags
   ext.authorized = authorized;
@@ -3035,7 +3039,7 @@ std::string surgeConfToClash(RESPONSE_CALLBACK_ARGS) {
   writeLog(0, "SurgeConfToClash 调用，URL：'" + url + "'。",
            LOG_LEVEL_INFO);
 
-  std::string proxy = parseProxy(global.proxyConfig);
+  ProxyPolicy proxy = parseProxy(global.proxyConfig);
   YAML::Node clash;
   template_args tpl_args;
   tpl_args.global_vars = global.templateVars;
@@ -3361,7 +3365,7 @@ std::string getProfile(RESPONSE_CALLBACK_ARGS) {
 /*
 std::string jinja2_webGet(const std::string &url)
 {
-    std::string proxy = parseProxy(global.proxyConfig);
+    ProxyPolicy proxy = parseProxy(global.proxyConfig);
     writeLog(0, "模板调用 fetch，URL：'" + url + "'。",
 LOG_LEVEL_INFO); return webGet(url, proxy, global.cacheConfig);
 }*/
@@ -3458,7 +3462,7 @@ int simpleGenerator() {
     writeLog(0, "正在生成所有生成项...", LOG_LEVEL_INFO);
 
   string_multimap allItems;
-  std::string proxy = parseProxy(global.proxySubscription);
+  ProxyPolicy proxy = parseProxy(global.proxySubscription);
   Request request;
   Response response;
   for (std::string &x : sections) {

--- a/src/handler/interfaces.h
+++ b/src/handler/interfaces.h
@@ -10,8 +10,6 @@
 #include "handler/fetch_context.h"
 #include "server/webserver.h"
 
-std::string parseProxy(const std::string &source);
-
 void refreshRulesets(RulesetConfigs &ruleset_list,
                      std::vector<RulesetContent> &rca,
                      FetchContext context = FetchContext::TrustedConfig);

--- a/src/handler/multithread.cpp
+++ b/src/handler/multithread.cpp
@@ -84,7 +84,7 @@ static bool canReadLocalFetchPath(const std::string &path,
     return false;
 }
 
-std::shared_future<std::string> fetchFileAsync(const std::string &path, const std::string &proxy, int cache_ttl, bool find_local, bool async, FetchContext context)
+std::shared_future<std::string> fetchFileAsync(const std::string &path, const ProxyPolicy &proxy, int cache_ttl, bool find_local, bool async, FetchContext context)
 {
     if(!async)
     {
@@ -107,7 +107,7 @@ std::shared_future<std::string> fetchFileAsync(const std::string &path, const st
     return retVal;
 }
 
-std::string fetchFile(const std::string &path, const std::string &proxy, int cache_ttl, bool find_local, FetchContext context)
+std::string fetchFile(const std::string &path, const ProxyPolicy &proxy, int cache_ttl, bool find_local, FetchContext context)
 {
     return fetchFileAsync(path, proxy, cache_ttl, find_local, false, context).get();
 }

--- a/src/handler/multithread.h
+++ b/src/handler/multithread.h
@@ -8,6 +8,7 @@
 
 #include "config/regmatch.h"
 #include "handler/fetch_context.h"
+#include "handler/proxy_policy.h"
 #include "utils/ini_reader/ini_reader.h"
 #include "utils/string.h"
 
@@ -27,10 +28,10 @@ void safe_set_streams(RegexMatchConfigs data);
 void safe_set_times(RegexMatchConfigs data);
 void safe_replace_settings(Settings &&settings);
 std::shared_future<std::string> fetchFileAsync(
-    const std::string &path, const std::string &proxy, int cache_ttl,
+    const std::string &path, const ProxyPolicy &proxy, int cache_ttl,
     bool find_local = true, bool async = false,
     FetchContext context = FetchContext::TrustedConfig);
-std::string fetchFile(const std::string &path, const std::string &proxy,
+std::string fetchFile(const std::string &path, const ProxyPolicy &proxy,
                       int cache_ttl, bool find_local = true,
                       FetchContext context = FetchContext::TrustedConfig);
 

--- a/src/handler/proxy_policy.cpp
+++ b/src/handler/proxy_policy.cpp
@@ -1,0 +1,229 @@
+#include <charconv>
+#include <cctype>
+#include <system_error>
+
+#include "utils/string.h"
+#include "utils/system.h"
+#include "proxy_policy.h"
+
+namespace {
+
+bool hasControlCharacter(const std::string &value) {
+  for (unsigned char character : value) {
+    if (std::iscntrl(character))
+      return true;
+  }
+  return false;
+}
+
+bool validPort(const std::string &port) {
+  if (port.empty())
+    return false;
+
+  unsigned int value = 0;
+  const auto [end, error] =
+      std::from_chars(port.data(), port.data() + port.size(), value);
+  return error == std::errc() && end == port.data() + port.size() &&
+         value > 0 && value <= 65535;
+}
+
+bool validProxyEndpoint(const std::string &endpoint, bool cors,
+                        std::string &error) {
+  if (endpoint.empty() || hasControlCharacter(endpoint)) {
+    error = "proxy URI is empty or contains a control character";
+    return false;
+  }
+
+  const std::string::size_type scheme_end = endpoint.find("://");
+  if (scheme_end == std::string::npos || scheme_end == 0) {
+    error = "proxy URI must include a scheme";
+    return false;
+  }
+
+  const std::string scheme = toLower(endpoint.substr(0, scheme_end));
+  const bool supported =
+      cors ? (scheme == "http" || scheme == "https")
+           : (scheme == "http" || scheme == "https" ||
+              scheme == "socks4" || scheme == "socks4a" ||
+              scheme == "socks5" || scheme == "socks5h");
+  if (!supported) {
+    error = cors ? "CORS endpoint must use http or https"
+                 : "unsupported proxy URI scheme";
+    return false;
+  }
+
+  const std::string authority_and_path = endpoint.substr(scheme_end + 3);
+  const std::string::size_type authority_end =
+      authority_and_path.find_first_of("/?#");
+  std::string authority = authority_and_path.substr(0, authority_end);
+  const std::string::size_type at = authority.rfind('@');
+  if (at != std::string::npos)
+    authority.erase(0, at + 1);
+  if (authority.empty()) {
+    error = "proxy URI is missing a host";
+    return false;
+  }
+
+  std::string port;
+  bool has_explicit_port = false;
+  if (authority.front() == '[') {
+    const std::string::size_type close = authority.find(']');
+    if (close == std::string::npos) {
+      error = "proxy URI has an invalid IPv6 host";
+      return false;
+    }
+    if (close + 1 < authority.size()) {
+      if (authority[close + 1] != ':') {
+        error = "proxy URI has an invalid IPv6 host and port";
+        return false;
+      }
+      port = authority.substr(close + 2);
+      has_explicit_port = true;
+    }
+  } else {
+    const std::string::size_type colon = authority.rfind(':');
+    if (colon == 0) {
+      error = "proxy URI is missing a host";
+      return false;
+    }
+    if (colon != std::string::npos) {
+      port = authority.substr(colon + 1);
+      has_explicit_port = true;
+    }
+  }
+
+  // Historical cors: examples use standard HTTP(S) ports implicitly. Keep
+  // that compatibility, while ordinary libcurl proxies require a port.
+  if (cors && !has_explicit_port)
+    return true;
+  if (!has_explicit_port || !validPort(port)) {
+    error = "proxy URI has an invalid port";
+    return false;
+  }
+  return true;
+}
+
+std::string redactEndpoint(const std::string &endpoint) {
+  const std::string::size_type scheme_end = endpoint.find("://");
+  if (scheme_end == std::string::npos)
+    return "<invalid>";
+
+  const std::string::size_type authority_start = scheme_end + 3;
+  const std::string::size_type authority_end =
+      endpoint.find_first_of("/?#", authority_start);
+  const std::string authority = endpoint.substr(
+      authority_start, authority_end == std::string::npos
+                           ? std::string::npos
+                           : authority_end - authority_start);
+  const std::string::size_type at = authority.rfind('@');
+  const std::string host_port =
+      at == std::string::npos ? authority : authority.substr(at + 1);
+  return endpoint.substr(0, scheme_end + 3) + host_port;
+}
+
+std::string normalizeSystemEndpoint(std::string endpoint) {
+  // Windows ProxyServer can be either a single host:port value or a
+  // semicolon-separated protocol map such as "http=...;https=...".  Libcurl
+  // needs one concrete proxy URI for the request.
+  if (endpoint.find("=") != std::string::npos) {
+    string_array entries = split(endpoint, ";");
+    std::string fallback;
+    for (const std::string &entry : entries) {
+      const std::string::size_type separator = entry.find('=');
+      if (separator == std::string::npos)
+        continue;
+      const std::string scheme =
+          toLower(trimWhitespace(entry.substr(0, separator), true, true));
+      const std::string value =
+          trimWhitespace(entry.substr(separator + 1), true, true);
+      if (value.empty())
+        continue;
+      if (scheme == "https" || scheme == "http")
+        return value.find("://") == std::string::npos ? "http://" + value
+                                                        : value;
+      if (fallback.empty())
+        fallback = value;
+    }
+    endpoint = fallback;
+  }
+  if (!endpoint.empty() && endpoint.find("://") == std::string::npos)
+    endpoint = "http://" + endpoint;
+  return endpoint;
+}
+
+} // namespace
+
+ProxyPolicy ProxyPolicy::direct() { return {}; }
+
+ProxyPolicy ProxyPolicy::parse(const std::string &source) {
+  const std::string value = trimWhitespace(source, true, true);
+  const std::string keyword = toUpper(value);
+  if (value.empty() || keyword == "NONE")
+    return direct();
+  if (keyword == "SYSTEM")
+    return {ProxyMode::System, "", true, ""};
+
+  if (startsWith(toLower(value), "cors:")) {
+    ProxyPolicy policy {ProxyMode::Cors, value.substr(5), true, ""};
+    policy.valid = validProxyEndpoint(policy.endpoint, true, policy.error);
+    return policy;
+  }
+
+  ProxyPolicy policy {ProxyMode::Explicit, value, true, ""};
+  policy.valid = validProxyEndpoint(policy.endpoint, false, policy.error);
+  return policy;
+}
+
+ProxyPolicy ProxyPolicy::resolved() const {
+  ProxyPolicy result = *this;
+  if (result.mode != ProxyMode::System)
+    return result;
+
+  result.endpoint = normalizeSystemEndpoint(
+      trimWhitespace(getSystemProxy(), true, true));
+  if (result.endpoint.empty())
+    return result;
+
+  std::string validation_error;
+  if (!validProxyEndpoint(result.endpoint, false, validation_error)) {
+    result.valid = false;
+    result.error = "system proxy is invalid: " + validation_error;
+  }
+  return result;
+}
+
+std::string ProxyPolicy::cacheIdentity() const {
+  const ProxyPolicy effective = resolved();
+  return std::string(proxyModeName(effective.mode)) + "\n" +
+         effective.endpoint + "\n" + (effective.valid ? "valid" : "invalid");
+}
+
+std::string ProxyPolicy::describe() const {
+  const ProxyPolicy effective = resolved();
+  std::string description = proxyModeName(effective.mode);
+  if (!effective.valid)
+    return description + " (invalid)";
+  if (!effective.endpoint.empty())
+    description += " " + redactEndpoint(effective.endpoint);
+  else if (effective.mode == ProxyMode::System)
+    description += " (no system proxy configured)";
+  return description;
+}
+
+ProxyPolicy parseProxy(const std::string &source) {
+  return ProxyPolicy::parse(source);
+}
+
+const char *proxyModeName(ProxyMode mode) {
+  switch (mode) {
+  case ProxyMode::Direct:
+    return "Direct";
+  case ProxyMode::System:
+    return "System";
+  case ProxyMode::Explicit:
+    return "Explicit";
+  case ProxyMode::Cors:
+    return "Cors";
+  }
+  return "Unknown";
+}

--- a/src/handler/proxy_policy.h
+++ b/src/handler/proxy_policy.h
@@ -1,0 +1,41 @@
+#ifndef PROXY_POLICY_H_INCLUDED
+#define PROXY_POLICY_H_INCLUDED
+
+#include <string>
+
+// Keep the user's proxy intent until the request reaches libcurl.  An empty
+// string is deliberately Direct, not an implicit request to read curl's
+// environment variables.
+enum class ProxyMode {
+  Direct,
+  System,
+  Explicit,
+  Cors,
+};
+
+struct ProxyPolicy {
+  ProxyMode mode = ProxyMode::Direct;
+  std::string endpoint;
+  bool valid = true;
+  std::string error;
+
+  static ProxyPolicy direct();
+  static ProxyPolicy parse(const std::string &source);
+
+  // Resolve the deterministic System source without changing its mode.  The
+  // empty endpoint means that the configured system source has no proxy.
+  ProxyPolicy resolved() const;
+
+  // Suitable for cache identities, never for logs.  It intentionally retains
+  // credentials so two authenticated proxy endpoints cannot share a cache.
+  std::string cacheIdentity() const;
+  std::string describe() const;
+};
+
+// Compatibility name used by the existing settings call sites.  Unlike the
+// historical helper it returns a policy, not an ambiguous string.
+ProxyPolicy parseProxy(const std::string &source);
+
+const char *proxyModeName(ProxyMode mode);
+
+#endif // PROXY_POLICY_H_INCLUDED

--- a/src/handler/settings.cpp
+++ b/src/handler/settings.cpp
@@ -193,7 +193,7 @@ int importItems(string_array &target, bool scope_limit, FetchContext context) {
     writeLog(0, "正在导入项目：" + path);
     content.clear();
 
-    std::string proxy = parseProxy(global.proxyConfig);
+    ProxyPolicy proxy = parseProxy(global.proxyConfig);
 
     if (fileExist(path, scope_limit) && canImportLocalPath(path, context))
       content = fileGet(path, scope_limit);
@@ -240,7 +240,7 @@ void importItems(std::vector<toml::value> &root, const std::string &import_key,
   auto iter = root.begin();
   size_t count = 0;
 
-  std::string proxy = parseProxy(global.proxyConfig);
+  ProxyPolicy proxy = parseProxy(global.proxyConfig);
   while (iter != root.end()) {
     auto &table = iter->as_table();
     if (table.find("import") == table.end())
@@ -400,7 +400,7 @@ void refreshRulesets(RulesetConfigs &ruleset_list,
   std::string rule_group, rule_url, rule_url_typed, interval;
   RulesetContent rc;
 
-  std::string proxy = parseProxy(global.proxyRuleset);
+  ProxyPolicy proxy = parseProxy(global.proxyRuleset);
 
   for (RulesetConfig &x : ruleset_list) {
     rule_group = x.Group;
@@ -964,6 +964,7 @@ void readTOMLConf(toml::value &root) {
   auto tasks = toml::find_or<std::vector<toml::value>>(root, "tasks", {});
   importItems(tasks, "tasks", false);
   global.cronTasks = toml::get<CronTaskConfigs>(toml::value(tasks));
+  global.enableCron = !global.cronTasks.empty();
 
   auto section_server = toml::find(root, "server");
 
@@ -1635,9 +1636,9 @@ int loadExternalTOML(toml::value &root, ExternalConfig &ext,
 
 int loadExternalConfig(std::string &path, ExternalConfig &ext,
                        FetchContext context) {
-  std::string base_content, proxy = parseProxy(global.proxyConfig),
-                            config = fetchFile(path, proxy, global.cacheConfig,
-                                               true, context);
+  std::string base_content;
+  ProxyPolicy proxy = parseProxy(global.proxyConfig);
+  std::string config = fetchFile(path, proxy, global.cacheConfig, true, context);
   if (render_template(config, *ext.tpl_args, base_content,
                       global.templatePath, context) != 0)
     base_content = config;

--- a/src/handler/settings.cpp
+++ b/src/handler/settings.cpp
@@ -777,6 +777,7 @@ void readYAMLConf(YAML::Node &node) {
     node["advanced"]["enable_request_coalescing"] >>
         global.enableRequestCoalescing;
     node["advanced"]["coalesce_retry_on_5xx"] >> global.coalesceRetryOn5xx;
+    node["advanced"]["allow_insecure_tls"] >> global.allowInsecureTls;
     node["advanced"]["response_cache_ttl"] >> global.responseCacheTtl;
   }
   if (node["statistics"].IsDefined()) {
@@ -992,6 +993,7 @@ void readTOMLConf(toml::value &root) {
       global.asyncFetchRuleset, "skip_failed_links", global.skipFailedLinks,
       "enable_request_coalescing", global.enableRequestCoalescing,
       "coalesce_retry_on_5xx", global.coalesceRetryOn5xx,
+      "allow_insecure_tls", global.allowInsecureTls,
       "response_cache_ttl", global.responseCacheTtl);
 
   if (global.printDbgInfo)
@@ -1446,6 +1448,7 @@ bool readConf() {
   ini.get_bool_if_exist("enable_request_coalescing",
                         global.enableRequestCoalescing);
   ini.get_bool_if_exist("coalesce_retry_on_5xx", global.coalesceRetryOn5xx);
+  ini.get_bool_if_exist("allow_insecure_tls", global.allowInsecureTls);
   ini.get_int_if_exist("response_cache_ttl", global.responseCacheTtl);
 
   if (ini.section_exist("statistics")) {

--- a/src/handler/settings.h
+++ b/src/handler/settings.h
@@ -82,6 +82,9 @@ struct Settings {
 
   // request coalescing and short-lived response cache
   bool enableRequestCoalescing = true, coalesceRetryOn5xx = true;
+  // Secure TLS is the default. This is an explicit compatibility escape hatch
+  // for outbound libcurl requests only.
+  bool allowInsecureTls = false;
   int responseCacheTtl = 0;
   unsigned long long configGeneration = 0;
 

--- a/src/handler/upload.cpp
+++ b/src/handler/upload.cpp
@@ -4,7 +4,22 @@
 #include "utils/logger.h"
 #include "utils/rapidjson_extra.h"
 #include "utils/system.h"
+#include "handler/settings.h"
 #include "webget.h"
+
+namespace {
+
+std::string gistApiUrl(const std::string &path)
+{
+    std::string base = trimWhitespace(getEnv("SUBCONVERTER_GIST_API_BASE"), true, true);
+    if(base.empty())
+        base = "https://api.github.com";
+    while(endsWith(base, "/"))
+        base.pop_back();
+    return base + path;
+}
+
+}
 
 std::string buildGistData(std::string name, std::string content)
 {
@@ -71,7 +86,7 @@ int uploadGist(std::string name, std::string path, std::string content, bool wri
     {
         //std::cerr<<"No gist id is provided. Creating new gist...\n";
         writeLog(0, "未提供 Gist ID，正在创建新 Gist...", LOG_LEVEL_ERROR);
-        retVal = webPost("https://api.github.com/gists", buildGistData(path, content), getSystemProxy(), {{"Authorization", "token " + token}}, &retData);
+        retVal = webPost(gistApiUrl("/gists"), buildGistData(path, content), parseProxy(global.proxyConfig), {{"Authorization", "token " + token}}, &retData);
         if(retVal != 201)
         {
             //std::cerr<<"Create new Gist failed! Return data:\n"<<retData<<"\n";
@@ -86,7 +101,7 @@ int uploadGist(std::string name, std::string path, std::string content, bool wri
         writeLog(0, "已提供 Gist ID，正在修改 Gist...", LOG_LEVEL_INFO);
         if(writeManageURL)
             content = "#!MANAGED-CONFIG " + url + "\n" + content;
-        retVal = webPatch("https://api.github.com/gists/" + id, buildGistData(path, content), getSystemProxy(), {{"Authorization", "token " + token}}, &retData);
+        retVal = webPatch(gistApiUrl("/gists/" + id), buildGistData(path, content), parseProxy(global.proxyConfig), {{"Authorization", "token " + token}}, &retData);
         if(retVal != 200)
         {
             //std::cerr<<"Modify gist failed! Return data:\n"<<retData<<"\n";

--- a/src/handler/webget.cpp
+++ b/src/handler/webget.cpp
@@ -18,6 +18,7 @@
 #include "utils/lock.h"
 #include "utils/logger.h"
 #include "utils/network.h"
+#include "utils/system.h"
 #include "utils/urlencode.h"
 #include "version.h"
 #include "webget.h"

--- a/src/handler/webget.cpp
+++ b/src/handler/webget.cpp
@@ -71,14 +71,15 @@ static CURLcode curl_init()
     return init_result;
 }
 
-static std::string build_cache_key(const std::string &url, const std::string &proxy,
+static std::string build_cache_key(const std::string &url, const ProxyPolicy &proxy,
                                    const string_icase_map *request_headers)
 {
-    if(proxy.empty() && (!request_headers || request_headers->empty()))
+    if(proxy.mode == ProxyMode::Direct && (!request_headers || request_headers->empty()))
         return getMD5(url);
 
     std::string identity = "url:" + std::to_string(url.size()) + ":" + url;
-    identity += "\nproxy:" + std::to_string(proxy.size()) + ":" + proxy;
+    const std::string proxy_identity = proxy.cacheIdentity();
+    identity += "\nproxy:" + std::to_string(proxy_identity.size()) + ":" + proxy_identity;
     identity += "\nheaders:";
     if(request_headers)
     {
@@ -201,7 +202,8 @@ static bool build_jsdelivr_github_url(const std::string &url,
        !parse_github_file_url(clean_url, file_ref))
         return false;
 
-    fallback_url = "https://cdn.jsdelivr.net/gh/" + file_ref.owner + "/" +
+    const std::string scheme = startsWith(clean_url, "http://") ? "http" : "https";
+    fallback_url = scheme + "://cdn.jsdelivr.net/gh/" + file_ref.owner + "/" +
                    file_ref.repo + "@" + file_ref.ref + "/" + file_ref.path;
     return true;
 }
@@ -504,8 +506,8 @@ static inline void curl_set_common_options(CURL *curl_handle, const char *url, c
     curl_easy_setopt(curl_handle, CURLOPT_NOSIGNAL, 1L);
     curl_easy_setopt(curl_handle, CURLOPT_FOLLOWLOCATION, 1L);
     curl_easy_setopt(curl_handle, CURLOPT_MAXREDIRS, 20L);
-    curl_easy_setopt(curl_handle, CURLOPT_SSL_VERIFYPEER, 0L);
-    curl_easy_setopt(curl_handle, CURLOPT_SSL_VERIFYHOST, 0L);
+    curl_easy_setopt(curl_handle, CURLOPT_SSL_VERIFYPEER, 1L);
+    curl_easy_setopt(curl_handle, CURLOPT_SSL_VERIFYHOST, 2L);
     curl_easy_setopt(curl_handle, CURLOPT_TIMEOUT, 15L);
     curl_easy_setopt(curl_handle, CURLOPT_COOKIEFILE, "");
     if(data)
@@ -514,6 +516,98 @@ static inline void curl_set_common_options(CURL *curl_handle, const char *url, c
             curl_easy_setopt(curl_handle, CURLOPT_MAXFILESIZE, data->size_limit);
         curl_easy_setopt(curl_handle, CURLOPT_XFERINFOFUNCTION, size_checker);
         curl_easy_setopt(curl_handle, CURLOPT_XFERINFODATA, data);
+    }
+}
+
+static CURLcode apply_curl_proxy_policy(CURL *curl_handle,
+                                        const ProxyPolicy &requested,
+                                        std::string &url,
+                                        ProxyPolicy &effective)
+{
+    effective = requested.resolved();
+    if(!effective.valid)
+    {
+        writeLog(0, "出站代理配置无效：" + effective.describe() + "。",
+                 LOG_LEVEL_ERROR);
+        return CURLE_URL_MALFORMAT;
+    }
+
+    switch(effective.mode)
+    {
+    case ProxyMode::Direct:
+        // CURLOPT_PROXY="" is libcurl's documented way to suppress every
+        // environment-derived proxy for this request.
+        curl_easy_setopt(curl_handle, CURLOPT_PROXY, "");
+        break;
+    case ProxyMode::System:
+        if(effective.endpoint.empty())
+            curl_easy_setopt(curl_handle, CURLOPT_PROXY, "");
+        else
+            curl_easy_setopt(curl_handle, CURLOPT_PROXY,
+                             effective.endpoint.c_str());
+        // Do not set CURLOPT_NOPROXY here: System intentionally preserves the
+        // platform's NO_PROXY/no_proxy behaviour.
+        break;
+    case ProxyMode::Explicit:
+        curl_easy_setopt(curl_handle, CURLOPT_PROXY, effective.endpoint.c_str());
+        // An explicitly configured proxy is fail-closed and must not be
+        // bypassed by an inherited NO_PROXY/no_proxy environment variable.
+        curl_easy_setopt(curl_handle, CURLOPT_NOPROXY, "");
+        break;
+    case ProxyMode::Cors:
+        // cors: names an HTTP relay URL, not a libcurl network proxy.  Its
+        // transport is direct so ambient proxy variables cannot alter it.
+        curl_easy_setopt(curl_handle, CURLOPT_PROXY, "");
+        url = effective.endpoint + url;
+        break;
+    }
+
+    if(shouldLog(LOG_LEVEL_VERBOSE))
+        writeLog(0, "出站代理策略：" + effective.describe() + "。",
+                 LOG_LEVEL_VERBOSE);
+    return CURLE_OK;
+}
+
+static const char *classify_curl_error(CURLcode code)
+{
+    switch(code)
+    {
+    case CURLE_OK:
+        return "none";
+    case CURLE_COULDNT_RESOLVE_PROXY:
+        return "proxy_dns";
+#if LIBCURL_VERSION_NUM >= 0x074900
+    case CURLE_PROXY:
+        return "proxy";
+#endif
+    case CURLE_SSL_CONNECT_ERROR:
+    case CURLE_PEER_FAILED_VERIFICATION:
+        return "tls";
+    case CURLE_LOGIN_DENIED:
+        return "authentication";
+    default:
+        return "transport";
+    }
+}
+
+// A single retry is intentionally limited to idempotent transfers and errors
+// that can plausibly be transient.  Authentication, TLS, policy validation,
+// HTTP status failures, and non-idempotent uploads never take this path.
+static bool is_recoverable_curl_error(CURLcode code)
+{
+    switch(code)
+    {
+    case CURLE_COULDNT_RESOLVE_PROXY:
+    case CURLE_COULDNT_RESOLVE_HOST:
+    case CURLE_COULDNT_CONNECT:
+    case CURLE_OPERATION_TIMEDOUT:
+    case CURLE_RECV_ERROR:
+    case CURLE_SEND_ERROR:
+    case CURLE_GOT_NOTHING:
+    case CURLE_PARTIAL_FILE:
+        return true;
+    default:
+        return false;
     }
 }
 
@@ -546,22 +640,29 @@ static int curlGet(const FetchArgument &argument, FetchResult &result, CURLcode 
         writeLog(0, "curl_easy_init 失败。", LOG_LEVEL_ERROR);
         return 0;
     }
-    if(!argument.proxy.empty())
+    ProxyPolicy effective_proxy;
+    retVal = apply_curl_proxy_policy(curl_handle, argument.proxy, new_url,
+                                     effective_proxy);
+    if(retVal != CURLE_OK)
     {
-        if(startsWith(argument.proxy, "cors:"))
-        {
-            header_list = curl_slist_append(header_list, "X-Requested-With: SubConverter-Extended " VERSION);
-            new_url = argument.proxy.substr(5) + argument.url;
-        }
-        else
-            curl_easy_setopt(curl_handle, CURLOPT_PROXY, argument.proxy.data());
+        *result.status_code = 0;
+        if(return_code)
+            *return_code = retVal;
+        curl_easy_cleanup(curl_handle);
+        return 0;
     }
+    if(effective_proxy.mode == ProxyMode::Cors)
+        header_list = curl_slist_append(header_list,
+                                        "X-Requested-With: SubConverter-Extended " VERSION);
     curl_progress_data limit;
     limit.size_limit = global.maxAllowedDownloadSize;
     curl_set_common_options(curl_handle, new_url.data(), &limit);
 #if LIBCURL_VERSION_NUM >= 0x075000
     FetchContext prereq_context = argument.context;
-    if(isPublicFetchRestricted(argument.context) && argument.proxy.empty())
+    if(isPublicFetchRestricted(argument.context) &&
+       (effective_proxy.mode == ProxyMode::Direct ||
+        (effective_proxy.mode == ProxyMode::System &&
+         effective_proxy.endpoint.empty())))
     {
         curl_easy_setopt(curl_handle, CURLOPT_PREREQFUNCTION,
                          public_fetch_prereq_callback);
@@ -631,14 +732,19 @@ static int curlGet(const FetchArgument &argument, FetchResult &result, CURLcode 
         break;
     }
 
-    unsigned int fail_count = 0, max_fails = 1;
-    while(true)
+    retVal = curl_easy_perform(curl_handle);
+    if(retVal != CURLE_OK &&
+       (argument.method == HTTP_GET || argument.method == HTTP_HEAD) &&
+       is_recoverable_curl_error(retVal))
     {
+        writeLog(0, "出站请求遇到可恢复网络错误，200ms 后重试一次。",
+                 LOG_LEVEL_WARNING);
+        if(result.content)
+            result.content->clear();
+        if(result.response_headers)
+            result.response_headers->clear();
+        sleepMs(200);
         retVal = curl_easy_perform(curl_handle);
-        if(retVal == CURLE_OK || max_fails <= fail_count || global.APIMode)
-            break;
-        else
-            fail_count++;
     }
 
     long code = 0;
@@ -646,6 +752,26 @@ static int curlGet(const FetchArgument &argument, FetchResult &result, CURLcode 
     *result.status_code = code;
     if(return_code)
         *return_code = retVal;
+
+#if LIBCURL_VERSION_NUM >= 0x080700
+    long used_proxy = 0;
+    if(curl_easy_getinfo(curl_handle, CURLINFO_USED_PROXY, &used_proxy) == CURLE_OK &&
+       shouldLog(LOG_LEVEL_VERBOSE))
+        writeLog(0, std::string("出站代理实际使用：") +
+                        (used_proxy ? "是" : "否") + "。",
+                 LOG_LEVEL_VERBOSE);
+#endif
+#if LIBCURL_VERSION_NUM >= 0x074900
+    long proxy_error = 0;
+    if(curl_easy_getinfo(curl_handle, CURLINFO_PROXY_ERROR, &proxy_error) == CURLE_OK &&
+       proxy_error != 0 && shouldLog(LOG_LEVEL_VERBOSE))
+        writeLog(0, "出站代理错误代码：" + std::to_string(proxy_error) + "。",
+                 LOG_LEVEL_VERBOSE);
+#endif
+    if(retVal != CURLE_OK && shouldLog(LOG_LEVEL_VERBOSE))
+        writeLog(0, "出站请求错误类别：" +
+                        std::string(classify_curl_error(retVal)) + "。",
+                 LOG_LEVEL_VERBOSE);
 
     if(result.cookies)
     {
@@ -767,7 +893,7 @@ std::string buildSocks5ProxyString(const std::string &addr, int port, const std:
     return proxystr;
 }
 
-std::string webGet(const std::string &url, const std::string &proxy, unsigned int cache_ttl, std::string *response_headers, string_icase_map *request_headers, FetchContext context)
+std::string webGet(const std::string &url, const ProxyPolicy &proxy, unsigned int cache_ttl, std::string *response_headers, string_icase_map *request_headers, FetchContext context)
 {
     int return_code = 0;
     std::string content;
@@ -887,7 +1013,7 @@ void flushCache()
     operateFiles("cache", [](const std::string &file){ remove(("cache/" + file).data()); return 0; });
 }
 
-int webPost(const std::string &url, const std::string &data, const std::string &proxy, const string_icase_map &request_headers, std::string *retData)
+int webPost(const std::string &url, const std::string &data, const ProxyPolicy &proxy, const string_icase_map &request_headers, std::string *retData)
 {
     //return curlPost(url, data, proxy, request_headers, retData);
     int return_code = 0;
@@ -896,7 +1022,7 @@ int webPost(const std::string &url, const std::string &data, const std::string &
     return webGet(argument, fetch_res);
 }
 
-int webPatch(const std::string &url, const std::string &data, const std::string &proxy, const string_icase_map &request_headers, std::string *retData)
+int webPatch(const std::string &url, const std::string &data, const ProxyPolicy &proxy, const string_icase_map &request_headers, std::string *retData)
 {
     //return curlPatch(url, data, proxy, request_headers, retData);
     int return_code = 0;
@@ -905,7 +1031,7 @@ int webPatch(const std::string &url, const std::string &data, const std::string 
     return webGet(argument, fetch_res);
 }
 
-int webHead(const std::string &url, const std::string &proxy, const string_icase_map &request_headers, std::string &response_headers)
+int webHead(const std::string &url, const ProxyPolicy &proxy, const string_icase_map &request_headers, std::string &response_headers)
 {
     //return curlHead(url, proxy, request_headers, response_headers);
     int return_code = 0;

--- a/src/handler/webget.cpp
+++ b/src/handler/webget.cpp
@@ -506,8 +506,10 @@ static inline void curl_set_common_options(CURL *curl_handle, const char *url, c
     curl_easy_setopt(curl_handle, CURLOPT_NOSIGNAL, 1L);
     curl_easy_setopt(curl_handle, CURLOPT_FOLLOWLOCATION, 1L);
     curl_easy_setopt(curl_handle, CURLOPT_MAXREDIRS, 20L);
-    curl_easy_setopt(curl_handle, CURLOPT_SSL_VERIFYPEER, 1L);
-    curl_easy_setopt(curl_handle, CURLOPT_SSL_VERIFYHOST, 2L);
+    curl_easy_setopt(curl_handle, CURLOPT_SSL_VERIFYPEER,
+                     global.allowInsecureTls ? 0L : 1L);
+    curl_easy_setopt(curl_handle, CURLOPT_SSL_VERIFYHOST,
+                     global.allowInsecureTls ? 0L : 2L);
     curl_easy_setopt(curl_handle, CURLOPT_TIMEOUT, 15L);
     curl_easy_setopt(curl_handle, CURLOPT_COOKIEFILE, "");
     if(data)

--- a/src/handler/webget.h
+++ b/src/handler/webget.h
@@ -5,6 +5,7 @@
 #include <map>
 
 #include "handler/fetch_context.h"
+#include "handler/proxy_policy.h"
 #include "utils/map_extra.h"
 #include "utils/string.h"
 
@@ -20,7 +21,7 @@ struct FetchArgument
 {
     const http_method method;
     const std::string url;
-    const std::string proxy;
+    const ProxyPolicy proxy;
     const std::string *post_data = nullptr;
     const string_icase_map *request_headers = nullptr;
     std::string *cookies = nullptr;
@@ -38,11 +39,19 @@ struct FetchResult
 };
 
 int webGet(const FetchArgument& argument, FetchResult &result);
-std::string webGet(const std::string &url, const std::string &proxy = "", unsigned int cache_ttl = 0, std::string *response_headers = nullptr, string_icase_map *request_headers = nullptr, FetchContext context = FetchContext::TrustedConfig);
+std::string webGet(const std::string &url, const ProxyPolicy &proxy,
+                   unsigned int cache_ttl = 0,
+                   std::string *response_headers = nullptr,
+                   string_icase_map *request_headers = nullptr,
+                   FetchContext context = FetchContext::TrustedConfig);
 bool isFetchUrlAllowed(const std::string &url, FetchContext context);
 void flushCache();
-int webPost(const std::string &url, const std::string &data, const std::string &proxy, const string_icase_map &request_headers, std::string *retData);
-int webPatch(const std::string &url, const std::string &data, const std::string &proxy, const string_icase_map &request_headers, std::string *retData);
+int webPost(const std::string &url, const std::string &data,
+            const ProxyPolicy &proxy, const string_icase_map &request_headers,
+            std::string *retData);
+int webPatch(const std::string &url, const std::string &data,
+             const ProxyPolicy &proxy, const string_icase_map &request_headers,
+             std::string *retData);
 std::string buildSocks5ProxyString(const std::string &addr, int port, const std::string &username, const std::string &password);
 
 // Unimplemented: (CURLOPT_HTTPHEADER: Host:)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -330,7 +330,7 @@ int main(int argc, char *argv[]) {
                               [](RESPONSE_CALLBACK_ARGS) -> std::string {
                                 std::string url = urlDecode(
                                     getUrlArg(request.argument, "url"));
-                                return webGet(url, "");
+                                return webGet(url, parseProxy(global.proxyConfig));
                               });
 
     webServer.append_response(

--- a/src/script/cron.cpp
+++ b/src/script/cron.cpp
@@ -45,7 +45,7 @@ void refresh_schedule() {
       try {
         script_runtime_init(runtime);
         script_context_init(context);
-        defer(script_cleanup(context);) std::string proxy =
+        defer(script_cleanup(context);) ProxyPolicy proxy =
             parseProxy(global.proxyConfig);
         std::string script = fetchFile(x.Path, proxy, global.cacheConfig);
         if (script.empty()) {

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -13,8 +13,6 @@
 extern int gCacheConfig;
 extern std::string gProxyConfig;
 
-std::string parseProxy(const std::string &source);
-
 std::string foldPathString(const std::string &path)
 {
     std::string output = path;
@@ -117,13 +115,15 @@ static duk_ret_t fetch(duk_context *ctx)
     std::string filepath, proxy, method, postdata, content;
     if(duktape_get_arguments_str(ctx, 1, 4, &filepath, &proxy, &method, &postdata) == 0)
         return 0;
+    ProxyPolicy policy = proxy.empty() ? parseProxy(gProxyConfig)
+                                       : parseProxy(proxy);
     switch(hash_(method))
     {
     case "POST"_hash:
-        webPost(filepath, postdata, proxy, string_array{}, &content);
+        webPost(filepath, postdata, policy, string_array{}, &content);
         break;
     default:
-        content = fetchFile(filepath, proxy, gCacheConfig);
+        content = fetchFile(filepath, policy, gCacheConfig);
         break;
     }
     duk_push_lstring(ctx, content.c_str(), content.size());
@@ -154,7 +154,9 @@ static duk_ret_t getGeoIP(duk_context *ctx)
     if(address.empty())
         duk_push_undefined(ctx);
     else
-        duk_push_string(ctx, fetchFile("https://api.ip.sb/geoip/" + address, parseProxy(proxy), gCacheConfig).c_str());
+        ProxyPolicy policy = proxy.empty() ? parseProxy(gProxyConfig)
+                                           : parseProxy(proxy);
+        duk_push_string(ctx, fetchFile("https://api.ip.sb/geoip/" + address, policy, gCacheConfig).c_str());
     return 1;
 }
 

--- a/src/script/script_quickjs.cpp
+++ b/src/script/script_quickjs.cpp
@@ -233,11 +233,8 @@ static bool qjs_has_own_property(JSContext *ctx, JSValueConst object,
                                  const char *name)
 {
     JSAtom property = JS_NewAtom(ctx, name);
-    JSPropertyDescriptor descriptor {};
-    const int found = JS_GetOwnProperty(ctx, &descriptor, object, property);
+    const int found = JS_HasOwnProperty(ctx, object, property);
     JS_FreeAtom(ctx, property);
-    if(found > 0)
-        JS_FreePropertyDescriptor(ctx, &descriptor);
     return found > 0;
 }
 

--- a/src/script/script_quickjs.cpp
+++ b/src/script/script_quickjs.cpp
@@ -335,7 +335,10 @@ namespace qjs
         static qjs_fetch_Request unwrap(JSContext *ctx, JSValueConst v)
         {
             qjs_fetch_Request request;
-            request.method = unwrap_free<std::string>(ctx, v, "method");
+            // Keep the documented Request default when the object literal only
+            // supplies a URL (the usual fetch({url: ...}) form).
+            if(qjs_has_own_property(ctx, v, "method"))
+                request.method = unwrap_free<std::string>(ctx, v, "method");
             request.url = unwrap_free<std::string>(ctx, v, "url");
             request.postdata = unwrap_free<std::string>(ctx, v, "data");
             request.proxy_specified = qjs_has_own_property(ctx, v, "proxy");

--- a/src/script/script_quickjs.cpp
+++ b/src/script/script_quickjs.cpp
@@ -1,4 +1,5 @@
 #include <string>
+#include <cstring>
 #include <map>
 #include <iostream>
 #include <quickjspp.hpp>

--- a/src/script/script_quickjs.cpp
+++ b/src/script/script_quickjs.cpp
@@ -17,8 +17,6 @@
 #include "utils/system.h"
 #include "script_quickjs.h"
 
-std::string parseProxy(const std::string &source);
-
 static const std::string qjs_require_module {R"(import * as std from 'std'
 import * as os from 'os'
 
@@ -224,11 +222,24 @@ public:
     std::string method = "GET";
     std::string url;
     std::string proxy;
+    bool proxy_specified = false;
     qjs_fetch_Headers headers;
     std::string cookies;
     std::string postdata;
     explicit qjs_fetch_Request(std::string url) : url(std::move(url)) {}
 };
+
+static bool qjs_has_own_property(JSContext *ctx, JSValueConst object,
+                                 const char *name)
+{
+    JSAtom property = JS_NewAtom(ctx, name);
+    JSPropertyDescriptor descriptor {};
+    const int found = JS_GetOwnProperty(ctx, &descriptor, object, property);
+    JS_FreeAtom(ctx, property);
+    if(found > 0)
+        JS_FreePropertyDescriptor(ctx, &descriptor);
+    return found > 0;
+}
 
 class qjs_fetch_Response
 {
@@ -313,7 +324,9 @@ namespace qjs
             request.method = unwrap_free<std::string>(ctx, v, "method");
             request.url = unwrap_free<std::string>(ctx, v, "url");
             request.postdata = unwrap_free<std::string>(ctx, v, "data");
-            request.proxy = unwrap_free<std::string>(ctx, v, "proxy");
+            request.proxy_specified = qjs_has_own_property(ctx, v, "proxy");
+            if(request.proxy_specified)
+                request.proxy = unwrap_free<std::string>(ctx, v, "proxy");
             request.cookies = unwrap_free<std::string>(ctx, v, "cookies");
             request.headers = unwrap_free<qjs_fetch_Headers>(ctx, v, "headers");
             return request;
@@ -366,7 +379,10 @@ static qjs_fetch_Response qjs_fetch(qjs_fetch_Request request)
     }
 
     std::string response_headers;
-    FetchArgument argument {method, request.url, request.proxy, &request.postdata, &request.headers.headers, &request.cookies, 0};
+    ProxyPolicy proxy = request.proxy_specified
+                            ? parseProxy(request.proxy)
+                            : parseProxy(global.proxyConfig);
+    FetchArgument argument {method, request.url, proxy, &request.postdata, &request.headers.headers, &request.cookies, 0};
     FetchResult result {&response.status_code, &response.content, &response_headers, &response.cookies};
 
     webGet(argument, result);
@@ -382,7 +398,9 @@ static std::string qjs_getUrlArg(const std::string &url, const std::string &requ
 
 std::string getGeoIP(const std::string &address, const std::string &proxy)
 {
-    return fetchFile("https://api.ip.sb/geoip/" + address, parseProxy(proxy), global.cacheConfig);
+    ProxyPolicy policy = proxy.empty() ? parseProxy(global.proxyConfig)
+                                       : parseProxy(proxy);
+    return fetchFile("https://api.ip.sb/geoip/" + address, policy, global.cacheConfig);
 }
 
 void script_runtime_init(qjs::Runtime &runtime)

--- a/src/script/script_quickjs.cpp
+++ b/src/script/script_quickjs.cpp
@@ -232,10 +232,26 @@ public:
 static bool qjs_has_own_property(JSContext *ctx, JSValueConst object,
                                  const char *name)
 {
-    JSAtom property = JS_NewAtom(ctx, name);
-    const int found = JS_HasOwnProperty(ctx, object, property);
-    JS_FreeAtom(ctx, property);
-    return found > 0;
+    JSPropertyEnum *properties = nullptr;
+    uint32_t count = 0;
+    if(JS_GetOwnPropertyNames(ctx, &properties, &count, object,
+                              JS_GPN_STRING_MASK | JS_GPN_ENUM_ONLY) < 0)
+        return false;
+
+    bool found = false;
+    for(uint32_t index = 0; index < count; index++)
+    {
+        const char *property = JS_AtomToCString(ctx, properties[index].atom);
+        if(property != nullptr)
+        {
+            found = found || std::strcmp(property, name) == 0;
+            JS_FreeCString(ctx, property);
+        }
+        JS_FreeAtom(ctx, properties[index].atom);
+    }
+    // JS_GetOwnPropertyNames allocates with QuickJS's allocator.
+    js_free(ctx, properties);
+    return found;
 }
 
 class qjs_fetch_Response

--- a/src/utils/logger.cpp
+++ b/src/utils/logger.cpp
@@ -12,6 +12,7 @@
 #include "defer.h"
 #include "lock.h"
 #include "logger.h"
+#include "redact.h"
 #include "time_compat.h"
 
 std::string getTime(int type)
@@ -77,7 +78,7 @@ void writeLog(int type, const std::string &content, int level)
     std::lock_guard<std::mutex> lock(log_mutex);
     const char *levels[] = {"[FATL]", "[ERRO]", "[WARN]", "[INFO]", "[DEBG]", "[VERB]"};
     std::cerr<<getTime(2)<<" ["<<getpid()<<" "<<get_thread_name()<<"]"<<levels[level % 6];
-    std::cerr<<" "<<content<<"\n";
+    std::cerr<<" "<<redactSensitiveLogText(content)<<"\n";
 }
 
 

--- a/src/utils/redact.cpp
+++ b/src/utils/redact.cpp
@@ -1,0 +1,95 @@
+#include <algorithm>
+
+#include "string.h"
+#include "redact.h"
+
+namespace {
+
+bool isUrlTerminator(char character) {
+  return character == '\0' || character == '\'' || character == '\"' ||
+         character == '<' || character == '>' || character == '\r' ||
+         character == '\n' || character == ' ' || character == '\t';
+}
+
+bool sensitiveParameter(const std::string &name) {
+  const std::string lower = toLower(name);
+  return lower == "token" || lower == "access_token" || lower == "api_key" ||
+         lower == "apikey" || lower == "key" || lower == "secret" ||
+         lower == "password" || lower == "pass" || lower == "authorization";
+}
+
+std::string redactUrl(std::string url) {
+  const std::string::size_type scheme_end = url.find("://");
+  if (scheme_end == std::string::npos)
+    return url;
+
+  const std::string::size_type authority_start = scheme_end + 3;
+  const std::string::size_type authority_end =
+      url.find_first_of("/?#", authority_start);
+  const std::string::size_type at = url.rfind(
+      '@', authority_end == std::string::npos ? std::string::npos : authority_end);
+  if (at != std::string::npos && at >= authority_start)
+    url.erase(authority_start, at + 1 - authority_start);
+
+  const std::string::size_type query_start = url.find('?');
+  if (query_start == std::string::npos)
+    return url;
+  const std::string::size_type fragment_start = url.find('#', query_start);
+  const std::string query = url.substr(
+      query_start + 1, fragment_start == std::string::npos
+                           ? std::string::npos
+                           : fragment_start - query_start - 1);
+  string_array pairs = split(query, "&");
+  for (std::string &pair : pairs) {
+    const std::string::size_type equals = pair.find('=');
+    const std::string name = pair.substr(0, equals);
+    if (sensitiveParameter(name) && equals != std::string::npos)
+      pair.erase(equals + 1), pair += "<redacted>";
+  }
+  url.replace(query_start + 1,
+              fragment_start == std::string::npos ? std::string::npos
+                                                   : fragment_start - query_start - 1,
+              join(pairs, "&"));
+  return url;
+}
+
+std::string redactHeaders(std::string text) {
+  const std::string lower = toLower(text);
+  const std::string::size_type proxy_authorization =
+      lower.find("proxy-authorization:");
+  if (proxy_authorization != std::string::npos)
+    return text.substr(0, proxy_authorization + 20) + " <redacted>";
+  const std::string::size_type authorization = lower.find("authorization:");
+  if (authorization != std::string::npos)
+    return text.substr(0, authorization + 14) + " <redacted>";
+  return text;
+}
+
+} // namespace
+
+std::string redactSensitiveLogText(const std::string &text) {
+  std::string result = redactHeaders(text);
+  static const string_array schemes = {"http://", "https://", "socks4://",
+                                       "socks4a://", "socks5://", "socks5h://"};
+  std::string lower = toLower(result);
+  std::string::size_type position = 0;
+  while (position < result.size()) {
+    std::string::size_type start = std::string::npos;
+    for (const std::string &scheme : schemes) {
+      const std::string::size_type candidate = lower.find(scheme, position);
+      if (candidate != std::string::npos &&
+          (start == std::string::npos || candidate < start))
+        start = candidate;
+    }
+    if (start == std::string::npos)
+      break;
+    std::string::size_type end = start;
+    while (end < result.size() && !isUrlTerminator(result[end]))
+      end++;
+    const std::string replacement = redactUrl(result.substr(start, end - start));
+    result.replace(start, end - start, replacement);
+    lower = toLower(result);
+    position = start + replacement.size();
+  }
+  return result;
+}

--- a/src/utils/redact.h
+++ b/src/utils/redact.h
@@ -1,0 +1,10 @@
+#ifndef REDACT_H_INCLUDED
+#define REDACT_H_INCLUDED
+
+#include <string>
+
+// Remove credentials, bearer values, and well-known URL secrets before text is
+// written to any diagnostic log sink.
+std::string redactSensitiveLogText(const std::string &text);
+
+#endif // REDACT_H_INCLUDED

--- a/tests/proxy_egress_integration.py
+++ b/tests/proxy_egress_integration.py
@@ -213,7 +213,9 @@ class SocksServer(socketserver.ThreadingTCPServer):
 class RunningContainer:
     def __init__(self, image: str, config: Path, port: int, env: dict[str, str], cache: Path | None = None, gist: Path | None = None) -> None:
         command = [
-            "docker", "run", "-d", "--rm", "--network", "host",
+            # Keep a failed container until close() so its startup log is
+            # available in the assertion output.
+            "docker", "run", "-d", "--network", "host",
             "--add-host", "target.test:127.0.0.1",
             "-v", f"{config}:/tmp/pref.toml:ro",
             "-e", "PREF_PATH=/tmp/pref.toml", "-e", f"PORT={port}",

--- a/tests/proxy_egress_integration.py
+++ b/tests/proxy_egress_integration.py
@@ -20,6 +20,7 @@ import subprocess
 import tempfile
 import threading
 import time
+import re
 import urllib.parse
 import urllib.error
 import urllib.request
@@ -267,30 +268,27 @@ def reserve_port() -> int:
 
 
 def write_config(path: Path, proxy_config: str, proxy_ruleset: str, proxy_subscription: str) -> None:
-    path.write_text(
-        "\n".join(
-            (
-                "version = 1",
-                "[common]",
-                'clash_rule_base = "/base/all_base.tpl"',
-                f'proxy_config = "{proxy_config}"',
-                f'proxy_ruleset = "{proxy_ruleset}"',
-                f'proxy_subscription = "{proxy_subscription}"',
-                "",
-                "[advanced]",
-                "log_level = 5",
-                "enable_cache = true",
-                "cache_subscription = 120",
-                "cache_config = 120",
-                "cache_ruleset = 120",
-                "",
-                "[server]",
-                'listen = "127.0.0.1"',
-                "port = 25500",
-            )
-        ),
-        encoding="utf-8",
-    )
+    # Keep every required preference section in the real distribution sample;
+    # this test changes only the egress knobs it is asserting.
+    example = Path(__file__).resolve().parents[1] / "base" / "pref.example.toml"
+    content = example.read_text(encoding="utf-8")
+
+    def replace(key: str, value: str) -> None:
+        nonlocal content
+        content, count = re.subn(
+            rf"(?m)^{re.escape(key)}\s*=.*$", f'{key} = {value}', content, count=1
+        )
+        if count != 1:
+            raise AssertionError(f"example preference is missing {key}")
+
+    replace("proxy_config", f'"{proxy_config}"')
+    replace("proxy_ruleset", f'"{proxy_ruleset}"')
+    replace("proxy_subscription", f'"{proxy_subscription}"')
+    replace("enable_cache", "true")
+    replace("cache_subscription", "120")
+    replace("cache_config", "120")
+    replace("cache_ruleset", "120")
+    path.write_text(content, encoding="utf-8")
 
 
 def add_cron_task(path: Path, script_url: str) -> None:

--- a/tests/proxy_egress_integration.py
+++ b/tests/proxy_egress_integration.py
@@ -1,0 +1,582 @@
+#!/usr/bin/env python3
+"""Deterministic Docker integration tests for outbound proxy policy.
+
+The test deliberately uses only loopback HTTP endpoints and a small SOCKS5
+implementation below.  It records the SOCKS address type and every target
+connection, so a green result proves routing rather than merely a successful
+HTTP response.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import http.server
+import os
+import select
+import socket
+import socketserver
+import subprocess
+import tempfile
+import threading
+import time
+import urllib.parse
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+SUBSCRIPTION = b"ss://YWVzLTEyOC1nY206cGFzc3dvcmQ@example.com:8388#ProxySmoke\n"
+
+
+def recv_exact(sock: socket.socket, size: int) -> bytes:
+    data = bytearray()
+    while len(data) < size:
+        chunk = sock.recv(size - len(data))
+        if not chunk:
+            raise ConnectionError("unexpected EOF")
+        data.extend(chunk)
+    return bytes(data)
+
+
+@dataclass
+class RequestRecord:
+    address_type: str
+    host: str
+    port: int
+
+
+@dataclass
+class Recorder:
+    requests: list[RequestRecord] = field(default_factory=list)
+    target_hits: list[str] = field(default_factory=list)
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def clear(self) -> None:
+        with self.lock:
+            self.requests.clear()
+            self.target_hits.clear()
+
+
+class FixtureHandler(http.server.BaseHTTPRequestHandler):
+    recorder: Recorder
+    target_name: str
+
+    def do_GET(self) -> None:  # noqa: N802
+        with self.recorder.lock:
+            self.recorder.target_hits.append(self.path)
+        if self.headers.get("Host", "").startswith("raw.githubusercontent.com"):
+            self.send_response(503)
+            self.end_headers()
+            return
+        if self.path.startswith("/redirect"):
+            self.send_response(302)
+            self.send_header(
+                "Location", f"http://{self.target_name}:{self.server.server_port}/subscription"
+            )
+            self.end_headers()
+            return
+        if self.path.startswith("/remote.ini"):
+            payload = (
+                "[custom]\n"
+                "enable_rule_generator=true\n"
+                f"ruleset=Proxy,http://{self.target_name}:{self.server.server_port}/rules.list\n"
+            ).encode("utf-8")
+        elif self.path.startswith("/rules.list"):
+            payload = b"DOMAIN,proxy-egress.example\n"
+        elif self.path.startswith("/cron.js"):
+            payload = (
+                f'fetch({{url:"http://{self.target_name}:{self.server.server_port}/quickjs-default"}});\n'
+                f'fetch({{url:"http://{self.target_name}:{self.server.server_port}/quickjs-none", proxy:"NONE"}});\n'
+                f'fetch({{url:"http://{self.target_name}:{self.server.server_port}/quickjs-system", proxy:"SYSTEM"}});\n'
+                f'fetch({{url:"http://{self.target_name}:{self.server.server_port}/quickjs-explicit", proxy:"{self.socks_uri}"}});\n'
+            ).encode("utf-8")
+        else:
+            payload = SUBSCRIPTION
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_POST(self) -> None:  # noqa: N802
+        with self.recorder.lock:
+            self.recorder.target_hits.append(self.path)
+        payload = b'{"id":"local-gist","owner":{"login":"proxy-test"}}'
+        self.send_response(201)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *_: object) -> None:
+        return
+
+
+class SocksHandler(socketserver.BaseRequestHandler):
+    server: "SocksServer"
+
+    def handle(self) -> None:
+        client: socket.socket = self.request
+        client.settimeout(10)
+        try:
+            version, method_count = recv_exact(client, 2)
+            if version != 5:
+                return
+            methods = recv_exact(client, method_count)
+            if self.server.username is None:
+                method = 0 if 0 in methods else 0xFF
+            else:
+                method = 2 if 2 in methods else 0xFF
+            client.sendall(bytes((5, method)))
+            if method == 0xFF:
+                return
+            if method == 2:
+                auth_version, user_length = recv_exact(client, 2)
+                username = recv_exact(client, user_length).decode("utf-8", "replace")
+                password_length = recv_exact(client, 1)[0]
+                password = recv_exact(client, password_length).decode("utf-8", "replace")
+                if auth_version != 1 or username != self.server.username or password != self.server.password:
+                    client.sendall(b"\x01\x01")
+                    return
+                client.sendall(b"\x01\x00")
+
+            version, command, _, atyp = recv_exact(client, 4)
+            if version != 5 or command != 1:
+                return
+            if atyp == 1:
+                host = socket.inet_ntoa(recv_exact(client, 4))
+                address_type = "IPv4"
+            elif atyp == 3:
+                host = recv_exact(client, recv_exact(client, 1)[0]).decode("idna")
+                address_type = "domain"
+            elif atyp == 4:
+                host = socket.inet_ntop(socket.AF_INET6, recv_exact(client, 16))
+                address_type = "IPv6"
+            else:
+                return
+            port = int.from_bytes(recv_exact(client, 2), "big")
+            with self.server.recorder.lock:
+                self.server.recorder.requests.append(RequestRecord(address_type, host, port))
+            if self.server.reject:
+                client.sendall(b"\x05\x05\x00\x01\x00\x00\x00\x00\x00\x00")
+                return
+
+            target = self.server.host_map.get(host, (host, port))
+            upstream = socket.create_connection(target, timeout=10)
+            with upstream:
+                client.sendall(b"\x05\x00\x00\x01\x00\x00\x00\x00\x00\x00")
+                self.relay(client, upstream)
+        except (ConnectionError, OSError, UnicodeError):
+            return
+
+    @staticmethod
+    def relay(left: socket.socket, right: socket.socket) -> None:
+        while True:
+            readable, _, _ = select.select((left, right), (), (), 10)
+            if not readable:
+                return
+            for source, destination in ((left, right), (right, left)):
+                if source not in readable:
+                    continue
+                data = source.recv(65536)
+                if not data:
+                    return
+                destination.sendall(data)
+
+
+class SocksServer(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+    def __init__(
+        self,
+        recorder: Recorder,
+        host_map: dict[str, tuple[str, int]],
+        username: str | None = None,
+        password: str | None = None,
+        reject: bool = False,
+    ) -> None:
+        super().__init__(("127.0.0.1", 0), SocksHandler)
+        self.recorder = recorder
+        self.host_map = host_map
+        self.username = username
+        self.password = password
+        self.reject = reject
+
+    @property
+    def port(self) -> int:
+        return self.server_address[1]
+
+
+class RunningContainer:
+    def __init__(self, image: str, config: Path, port: int, env: dict[str, str], cache: Path | None = None, gist: Path | None = None) -> None:
+        command = [
+            "docker", "run", "-d", "--rm", "--network", "host",
+            "--add-host", "target.test:127.0.0.1",
+            "-v", f"{config}:/tmp/pref.toml:ro",
+            "-e", "PREF_PATH=/tmp/pref.toml", "-e", f"PORT={port}",
+        ]
+        if cache is not None:
+            command += ["-v", f"{cache}:/tmp/cache"]
+        if gist is not None:
+            command += ["-v", f"{gist}:/base/gistconf.ini"]
+        for name, value in env.items():
+            command += ["-e", f"{name}={value}"]
+        command.append(image)
+        self.container_id = subprocess.check_output(command, text=True).strip()
+        self.port = port
+
+    def wait_ready(self) -> None:
+        url = f"http://127.0.0.1:{self.port}/healthz"
+        for _ in range(60):
+            try:
+                with urllib.request.urlopen(url, timeout=1) as response:
+                    if response.read().strip() == b"ok":
+                        return
+            except OSError:
+                time.sleep(0.5)
+        self.dump_logs()
+        raise AssertionError("SubConverter container did not become ready")
+
+    def dump_logs(self) -> None:
+        subprocess.run(["docker", "logs", self.container_id], check=False)
+
+    def logs(self) -> str:
+        return subprocess.check_output(["docker", "logs", self.container_id], text=True, stderr=subprocess.STDOUT)
+
+    def close(self) -> None:
+        subprocess.run(["docker", "rm", "-f", self.container_id], check=False,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    def __enter__(self) -> "RunningContainer":
+        self.wait_ready()
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+
+def reserve_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def write_config(path: Path, proxy_config: str, proxy_ruleset: str, proxy_subscription: str) -> None:
+    path.write_text(
+        "\n".join(
+            (
+                "[common]",
+                'clash_rule_base = "/base/all_base.tpl"',
+                f'proxy_config = "{proxy_config}"',
+                f'proxy_ruleset = "{proxy_ruleset}"',
+                f'proxy_subscription = "{proxy_subscription}"',
+                "",
+                "[advanced]",
+                "log_level = 5",
+                "enable_cache = true",
+                "cache_subscription = 120",
+                "cache_config = 120",
+                "cache_ruleset = 120",
+                "",
+                "[server]",
+                'listen = "127.0.0.1"',
+                "port = 25500",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+
+def add_cron_task(path: Path, script_url: str) -> None:
+    with path.open("a", encoding="utf-8") as output:
+        output.write(
+            "\n[[tasks]]\n"
+            'name = "proxy-egress"\n'
+            'cronexp = "0/1 * * * * ?"\n'
+            f'path = "{script_url}"\n'
+            "timeout = 5\n"
+        )
+
+
+def wait_until(condition: callable, timeout: float, message: str) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if condition():
+            return
+        time.sleep(0.2)
+    raise AssertionError(message)
+
+
+def sub_request(port: int, url: str, config: str = "data:,enable_rule_generator=false") -> str:
+    query = urllib.parse.urlencode(
+        {"target": "clash", "list": "true", "url": url, "config": config}
+    )
+    request_url = f"http://127.0.0.1:{port}/sub?{query}"
+    try:
+        with urllib.request.urlopen(request_url, timeout=15) as response:
+            body = response.read().decode("utf-8", "replace")
+            if response.status != 200 or "ProxySmoke" not in body:
+                raise AssertionError(f"unexpected /sub response: {response.status} {body[:300]}")
+            return body
+    except OSError as exc:
+        raise AssertionError(f"/sub request failed: {exc}") from exc
+
+
+def expect_sub_failure(port: int, url: str) -> None:
+    query = urllib.parse.urlencode(
+        {"target": "clash", "list": "true", "url": url, "config": "data:,enable_rule_generator=false"}
+    )
+    try:
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}/sub?{query}", timeout=15):
+            raise AssertionError("proxy failure unexpectedly produced a successful conversion")
+    except urllib.error.HTTPError:
+        return
+
+
+def upload_request(port: int) -> None:
+    query = urllib.parse.urlencode(
+        {"target": "clash", "url": "ss://YWVzLTEyOC1nY206cGFzc3dvcmQ@example.com:8388#UploadSmoke", "upload": "true"}
+    )
+    with urllib.request.urlopen(f"http://127.0.0.1:{port}/sub?{query}", timeout=15) as response:
+        if response.status != 200:
+            raise AssertionError(f"Gist upload conversion failed: {response.status}")
+
+
+def explain_request(port: int, url: str) -> str:
+    query = urllib.parse.urlencode(
+        {"target": "clash", "list": "true", "url": url, "config": "data:,enable_rule_generator=false", "explain": "true"}
+    )
+    with urllib.request.urlopen(f"http://127.0.0.1:{port}/sub?{query}", timeout=15) as response:
+        if response.status != 200:
+            raise AssertionError(f"explain endpoint failed: {response.status}")
+        return response.read().decode("utf-8", "replace")
+
+
+def provider_request(port: int, url: str) -> str:
+    query = urllib.parse.urlencode(
+        {"target": "clash", "url": url, "config": "data:,enable_rule_generator=false"}
+    )
+    with urllib.request.urlopen(f"http://127.0.0.1:{port}/sub?{query}", timeout=15) as response:
+        body = response.read().decode("utf-8", "replace")
+        if response.status != 200 or "proxy-providers" not in body:
+            raise AssertionError(f"unexpected Proxy-Provider response: {response.status} {body[:300]}")
+        return body
+
+
+def run(image: str) -> None:
+    recorder = Recorder()
+    fixture_class = type("ProxyFixtureHandler", (FixtureHandler,), {"recorder": recorder, "target_name": "target.test"})
+    fixture = http.server.ThreadingHTTPServer(("127.0.0.1", 0), fixture_class)
+    fixture_thread = threading.Thread(target=fixture.serve_forever, daemon=True)
+    fixture_thread.start()
+    host_map = {
+        "target.test": ("127.0.0.1", fixture.server_port),
+        "raw.githubusercontent.com": ("127.0.0.1", fixture.server_port),
+        "cdn.jsdelivr.net": ("127.0.0.1", fixture.server_port),
+    }
+    proxy = SocksServer(recorder, host_map)
+    proxy_thread = threading.Thread(target=proxy.serve_forever, daemon=True)
+    proxy_thread.start()
+    authenticated_proxy = SocksServer(
+        recorder, host_map, "user", "password"
+    )
+    authenticated_thread = threading.Thread(target=authenticated_proxy.serve_forever, daemon=True)
+    authenticated_thread.start()
+    fixture_class.socks_uri = f"socks5h://127.0.0.1:{proxy.port}"
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="sce-proxy-egress-") as temp_dir:
+            temp = Path(temp_dir)
+            remote_url = f"http://target.test:{fixture.server_port}/subscription"
+            redirect_url = f"http://target.test:{fixture.server_port}/redirect"
+            socks5h = f"socks5h://127.0.0.1:{proxy.port}"
+            socks5 = f"socks5://127.0.0.1:{proxy.port}"
+
+            def exercise(label: str, config_proxy: str, env: dict[str, str], url: str, expected_type: str | None) -> None:
+                recorder.clear()
+                config = temp / f"{label}.toml"
+                write_config(config, config_proxy, config_proxy, config_proxy)
+                with RunningContainer(image, config, reserve_port(), env) as container:
+                    sub_request(container.port, url)
+                with recorder.lock:
+                    records = list(recorder.requests)
+                    hits = list(recorder.target_hits)
+                if expected_type is None:
+                    assert not records, f"{label}: Direct request reached SOCKS proxy: {records}"
+                else:
+                    assert records, f"{label}: SOCKS proxy received no connection"
+                    assert records[0].address_type == expected_type, f"{label}: {records}"
+                assert hits, f"{label}: target server was never reached"
+
+            # Direct and an empty setting must actively ignore ALL_PROXY.
+            exercise("none", "NONE", {"ALL_PROXY": socks5h, "NO_PROXY": "", "no_proxy": ""}, remote_url, None)
+            exercise("empty", "", {"ALL_PROXY": socks5h, "NO_PROXY": "", "no_proxy": ""}, remote_url, None)
+
+            # System resolves the documented environment priority.  Explicit
+            # ignores NO_PROXY; socks5h sends a domain while socks5 sends IPv4.
+            exercise("system", "SYSTEM", {"ALL_PROXY": socks5h, "NO_PROXY": "", "no_proxy": ""}, remote_url, "domain")
+            exercise("explicit", socks5h, {"NO_PROXY": "*", "no_proxy": "*"}, remote_url, "domain")
+            exercise("socks5", socks5, {"NO_PROXY": "", "no_proxy": ""}, remote_url, "IPv4")
+
+            recorder.clear()
+            config = temp / "redirect.toml"
+            write_config(config, socks5h, socks5h, socks5h)
+            with RunningContainer(image, config, reserve_port(), {"NO_PROXY": "*", "no_proxy": "*"}) as container:
+                sub_request(container.port, redirect_url)
+            with recorder.lock:
+                assert len(recorder.requests) >= 2, "redirect did not keep using the SOCKS proxy"
+                assert all(item.address_type == "domain" for item in recorder.requests), recorder.requests
+
+            recorder.clear()
+            fallback_config = temp / "github-fallback.toml"
+            write_config(fallback_config, socks5h, socks5h, socks5h)
+            raw_url = "http://raw.githubusercontent.com/owner/repo/main/subscription"
+            with RunningContainer(image, fallback_config, reserve_port(), {}) as container:
+                sub_request(container.port, raw_url)
+            with recorder.lock:
+                fallback_hosts = [item.host for item in recorder.requests]
+                assert fallback_hosts[:2] == ["raw.githubusercontent.com", "cdn.jsdelivr.net"], fallback_hosts
+
+            # A caller-supplied external configuration and the ruleset it
+            # references use proxy_config and proxy_ruleset respectively.
+            recorder.clear()
+            config_ruleset = temp / "config-ruleset.toml"
+            write_config(config_ruleset, socks5h, socks5h, "NONE")
+            remote_config = f"http://target.test:{fixture.server_port}/remote.ini"
+            with RunningContainer(image, config_ruleset, reserve_port(), {}) as container:
+                sub_request(container.port, remote_url, config=remote_config)
+            with recorder.lock:
+                assert len(recorder.requests) >= 2, "external config or ruleset bypassed its proxy policy"
+                assert all(item.address_type == "domain" for item in recorder.requests), recorder.requests
+                assert "/remote.ini" in recorder.target_hits and "/rules.list" in recorder.target_hits, recorder.target_hits
+
+            # Cron retrieves its remote script through proxy_config. QuickJS
+            # fetch inherits proxy_config when absent, and each of NONE,
+            # SYSTEM, and a URI override changes that policy deliberately.
+            recorder.clear()
+            cron_config = temp / "cron.toml"
+            write_config(cron_config, socks5h, "NONE", "NONE")
+            add_cron_task(cron_config, f"http://target.test:{fixture.server_port}/cron.js")
+            with RunningContainer(
+                image, cron_config, reserve_port(), {"ALL_PROXY": socks5h, "NO_PROXY": "", "no_proxy": ""}
+            ):
+                def quickjs_complete() -> bool:
+                    with recorder.lock:
+                        return {"/cron.js", "/quickjs-default", "/quickjs-none", "/quickjs-system", "/quickjs-explicit"}.issubset(set(recorder.target_hits))
+                wait_until(quickjs_complete, 8, "Cron/QuickJS proxy policy requests did not all complete")
+            with recorder.lock:
+                proxied_paths = len(recorder.requests)
+                assert proxied_paths >= 4, f"Cron/QuickJS expected four SOCKS requests, got {recorder.requests}"
+
+            recorder.clear()
+            config = temp / "auth-ok.toml"
+            auth_uri = f"socks5h://user:password@127.0.0.1:{authenticated_proxy.port}"
+            write_config(config, auth_uri, auth_uri, auth_uri)
+            with RunningContainer(image, config, reserve_port(), {}) as container:
+                sub_request(container.port, remote_url)
+            with recorder.lock:
+                assert recorder.requests, "authenticated SOCKS request did not reach proxy"
+
+            # Runtime diagnostics and verbose curl logs carry a redacted
+            # endpoint only; credentials never escape through /sub?explain.
+            recorder.clear()
+            redaction_config = temp / "redaction.toml"
+            redaction_uri = f"socks5h://user:password@127.0.0.1:{authenticated_proxy.port}"
+            write_config(redaction_config, redaction_uri, "NONE", redaction_uri)
+            with RunningContainer(image, redaction_config, reserve_port(), {}) as container:
+                explain = explain_request(container.port, remote_url)
+                logs = container.logs()
+            assert "user:password" not in explain and "password" not in explain, explain
+            assert "user:password" not in logs and "password" not in logs, logs
+
+            recorder.clear()
+            config = temp / "auth-fail.toml"
+            wrong_auth = f"socks5h://user:wrong@127.0.0.1:{authenticated_proxy.port}"
+            write_config(config, wrong_auth, wrong_auth, wrong_auth)
+            with RunningContainer(image, config, reserve_port(), {}) as container:
+                expect_sub_failure(container.port, remote_url)
+            with recorder.lock:
+                assert not recorder.target_hits, "authentication failure fell back to a direct target connection"
+
+            recorder.clear()
+            config = temp / "invalid-proxy.toml"
+            invalid_proxy = "socks5h://missing-port.example.test"
+            write_config(config, invalid_proxy, invalid_proxy, invalid_proxy)
+            with RunningContainer(image, config, reserve_port(), {}) as container:
+                expect_sub_failure(container.port, remote_url)
+            with recorder.lock:
+                assert not recorder.target_hits, "invalid proxy configuration silently fell back to direct"
+
+            recorder.clear()
+            config = temp / "unavailable.toml"
+            unavailable = f"socks5h://127.0.0.1:{reserve_port()}"
+            write_config(config, unavailable, unavailable, unavailable)
+            with RunningContainer(image, config, reserve_port(), {}) as container:
+                expect_sub_failure(container.port, remote_url)
+            with recorder.lock:
+                assert not recorder.target_hits, "unavailable explicit proxy fell back to direct"
+
+            # A shared cache directory proves cache identities include both
+            # policy mode and endpoint rather than URL alone.
+            cache = temp / "cache"
+            cache.mkdir()
+            recorder.clear()
+            explicit_config = temp / "cache-explicit.toml"
+            write_config(explicit_config, socks5h, socks5h, socks5h)
+            with RunningContainer(image, explicit_config, reserve_port(), {}, cache) as container:
+                sub_request(container.port, remote_url)
+            recorder.clear()
+            direct_config = temp / "cache-direct.toml"
+            write_config(direct_config, "NONE", "NONE", "NONE")
+            with RunningContainer(image, direct_config, reserve_port(), {}, cache) as container:
+                sub_request(container.port, remote_url)
+            with recorder.lock:
+                assert recorder.target_hits and not recorder.requests, "Direct cache key reused explicit-proxy content"
+
+            # The Gist API is an auxiliary request and inherits proxy_config;
+            # its local API-base override exists only to make this test
+            # deterministic without contacting GitHub.
+            recorder.clear()
+            gist_conf = temp / "gistconf.ini"
+            gist_conf.write_text("[common]\\ntoken=fixture-token\\n", encoding="utf-8")
+            gist_config = temp / "gist.toml"
+            write_config(gist_config, socks5h, "NONE", "NONE")
+            with RunningContainer(
+                image, gist_config, reserve_port(),
+                {"SUBCONVERTER_GIST_API_BASE": f"http://target.test:{fixture.server_port}"},
+                gist=gist_conf,
+            ) as container:
+                upload_request(container.port)
+            with recorder.lock:
+                assert recorder.requests and recorder.requests[0].address_type == "domain", "Gist request bypassed proxy_config"
+                assert "/gists" in recorder.target_hits, "local Gist API did not receive the request"
+
+            # The default Clash Proxy-Provider path is a client-side pull:
+            # backend proxy_subscription must not pre-download it.
+            recorder.clear()
+            provider_config = temp / "provider.toml"
+            write_config(provider_config, "NONE", "NONE", socks5h)
+            with RunningContainer(image, provider_config, reserve_port(), {}) as container:
+                provider_request(container.port, remote_url)
+            with recorder.lock:
+                assert not recorder.requests and not recorder.target_hits, "Proxy-Provider unexpectedly downloaded the subscription in the backend"
+    finally:
+        proxy.shutdown()
+        authenticated_proxy.shutdown()
+        fixture.shutdown()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--image", required=True, help="locally built official Docker image")
+    args = parser.parse_args()
+    run(args.image)
+    print("proxy egress Docker integration tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/proxy_egress_integration.py
+++ b/tests/proxy_egress_integration.py
@@ -474,11 +474,14 @@ def run(image: str) -> None:
             add_cron_task(cron_config, f"http://target.test:{fixture.server_port}/cron.js")
             with RunningContainer(
                 image, cron_config, reserve_port(), {"ALL_PROXY": socks5h, "NO_PROXY": "", "no_proxy": ""}
-            ):
+            ) as container:
                 def quickjs_complete() -> bool:
                     with recorder.lock:
                         return {"/cron.js", "/quickjs-default", "/quickjs-none", "/quickjs-system", "/quickjs-explicit"}.issubset(set(recorder.target_hits))
-                wait_until(quickjs_complete, 8, "Cron/QuickJS proxy policy requests did not all complete")
+                try:
+                    wait_until(quickjs_complete, 8, "Cron/QuickJS proxy policy requests did not all complete")
+                except AssertionError as error:
+                    raise AssertionError(f"{error}\nSubConverter logs:\n{container.logs()}") from error
             with recorder.lock:
                 proxied_paths = len(recorder.requests)
                 assert proxied_paths >= 4, f"Cron/QuickJS expected four SOCKS requests, got {recorder.requests}"

--- a/tests/proxy_egress_integration.py
+++ b/tests/proxy_egress_integration.py
@@ -311,10 +311,16 @@ def wait_until(condition: callable, timeout: float, message: str) -> None:
     raise AssertionError(message)
 
 
-def sub_request(port: int, url: str, config: str = "data:,enable_rule_generator=false") -> str:
-    query = urllib.parse.urlencode(
-        {"target": "clash", "list": "true", "url": url, "config": config}
-    )
+def sub_request(
+    port: int,
+    url: str,
+    config: str = "data:,enable_rule_generator=false",
+    list_mode: bool = True,
+) -> str:
+    arguments = {"target": "clash", "url": url, "config": config}
+    if list_mode:
+        arguments["list"] = "true"
+    query = urllib.parse.urlencode(arguments)
     request_url = f"http://127.0.0.1:{port}/sub?{query}"
     try:
         with urllib.request.urlopen(request_url, timeout=15) as response:
@@ -448,7 +454,12 @@ def run(image: str) -> None:
             write_config(config_ruleset, socks5h, socks5h, "NONE")
             remote_config = f"http://target.test:{fixture.server_port}/remote.ini"
             with RunningContainer(image, config_ruleset, reserve_port(), {}) as container:
-                sub_request(container.port, remote_url, config=remote_config)
+                sub_request(
+                    container.port,
+                    "ss://YWVzLTEyOC1nY206cGFzc3dvcmQ@example.com:8388#ProxySmoke",
+                    config=remote_config,
+                    list_mode=False,
+                )
             with recorder.lock:
                 assert len(recorder.requests) >= 2, "external config or ruleset bypassed its proxy policy"
                 assert all(item.address_type == "domain" for item in recorder.requests), recorder.requests

--- a/tests/proxy_egress_integration.py
+++ b/tests/proxy_egress_integration.py
@@ -270,6 +270,7 @@ def write_config(path: Path, proxy_config: str, proxy_ruleset: str, proxy_subscr
     path.write_text(
         "\n".join(
             (
+                "version = 1",
                 "[common]",
                 'clash_rule_base = "/base/all_base.tpl"',
                 f'proxy_config = "{proxy_config}"',

--- a/tests/proxy_policy_test.cpp
+++ b/tests/proxy_policy_test.cpp
@@ -1,0 +1,47 @@
+#include <cassert>
+#include <string>
+
+#include "handler/proxy_policy.h"
+#include "utils/redact.h"
+
+int main() {
+  assert(parseProxy("").mode == ProxyMode::Direct);
+  assert(parseProxy("  NONE  ").mode == ProxyMode::Direct);
+  assert(parseProxy("none").mode == ProxyMode::Direct);
+  assert(parseProxy(" system ").mode == ProxyMode::System);
+
+  const ProxyPolicy socks5h =
+      parseProxy("socks5h://proxy.example.test:1080");
+  assert(socks5h.mode == ProxyMode::Explicit && socks5h.valid);
+  assert(socks5h.describe() == "Explicit socks5h://proxy.example.test:1080");
+
+  const ProxyPolicy authenticated =
+      parseProxy("socks5h://user:secret@proxy.example.test:1080");
+  assert(authenticated.valid);
+  assert(authenticated.describe().find("secret") == std::string::npos);
+  assert(authenticated.describe().find("user") == std::string::npos);
+
+  const ProxyPolicy cors = parseProxy("cors:https://cors.example.test:8443/");
+  assert(cors.mode == ProxyMode::Cors && cors.valid);
+  assert(parseProxy("cors:https://cors.example.test/").valid);
+  assert(!parseProxy("proxy.example.test:1080").valid);
+  assert(!parseProxy("socks5://proxy.example.test").valid);
+  assert(!parseProxy("ftp://proxy.example.test:21").valid);
+
+  const ProxyPolicy direct = parseProxy("NONE");
+  const ProxyPolicy system = parseProxy("SYSTEM");
+  const ProxyPolicy explicit_one = parseProxy("socks5://one.example.test:1080");
+  const ProxyPolicy explicit_two = parseProxy("socks5://two.example.test:1080");
+  assert(direct.cacheIdentity() != system.cacheIdentity());
+  assert(explicit_one.cacheIdentity() != explicit_two.cacheIdentity());
+  assert(direct.cacheIdentity() != explicit_one.cacheIdentity());
+
+  const std::string redacted = redactSensitiveLogText(
+      "CURL 请求头：> Authorization: Bearer private-token\n"
+      "proxy=socks5h://user:secret@proxy.example.test:1080 "
+      "url=https://example.test/sub?token=private-key");
+  assert(redacted.find("private-token") == std::string::npos);
+  assert(redacted.find("user:secret") == std::string::npos);
+  assert(redacted.find("private-key") == std::string::npos);
+  return 0;
+}


### PR DESCRIPTION
## Summary\n- introduce explicit Direct/System/Explicit/Cors outbound policy and apply it across libcurl callers\n- prevent environment/NO_PROXY bypasses, preserve fail-closed proxy behavior, redact diagnostics, and restore secure TLS defaults\n- add deterministic local SOCKS5 Docker regression coverage for config, rulesets, subscriptions, QuickJS/Cron, Gist, fallback, cache, and Proxy-Provider behavior\n\n## Validation\n- py -3 -m py_compile tests/proxy_egress_integration.py (local)\n- Docker/CTest integration workflow runs on this PR because the local workstation has no Docker engine or native C++ toolchain\n\n## Notes\n- The Docker integration uses an in-process local SOCKS5 fixture, not WireProxy.\n- socks5h compatibility is proven with a domain ATYP request; it does not claim a WireProxy run.