### PR TITLE
fix(server): support refreshed httplib params

### DIFF
--- a/src/server/webserver_httplib.cpp
+++ b/src/server/webserver_httplib.cpp
@@ -50,7 +50,9 @@ static httplib::Server::Handler makeHandler(const responseRoute &rr) {
       }
       req.headers.emplace(h.first.data(), h.second.data());
     }
-    req.argument = request.params;
+    for (const auto &param : request.params) {
+      req.argument.emplace(param.first, param.second);
+    }
     if (request.method == "POST" || request.method == "PUT" ||
         request.method == "PATCH") {
       if (request.get_header_value("Content-Type") ==


### PR DESCRIPTION
## Cause

The post-merge `dev` build run `31004084357` refreshes cpp-httplib to `2b8658fa99e6be67d1a8ee2a845f221abe4c5ac8`. In that version `httplib::Params` is an insertion-ordered container rather than `std::multimap`, so assigning it directly to the internal `string_multimap` fails to compile.

## Fix

Copy request parameters entry by entry. This is compatible with both the bundled header and the refreshed container while preserving duplicate parameters.

## Local verification

- Compiled `src/server/webserver_httplib.cpp` against exact refreshed httplib commit `2b8658f...`
- Dependency snapshot passed
- Python tests: 8/8
- UCRT64 Debug and Release builds passed
- CTest: 11/11
- Local health/version/sub HTTP smoke passed

This PR only repairs the dev build after PR #93. It does not modify or synchronize `master`.