### PR TITLE
ci(dependabot): require validation before auto-merge

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -2,7 +2,9 @@ name: Auto-merge Dependabot PRs
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    branches:
+      - dev
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
 
 permissions:
   contents: write
@@ -11,21 +13,100 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.actor == 'dependabot[bot]' && github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
-      - name: Merge Dependabot PR
-        uses: actions/github-script@v9
+      - name: Register native auto-merge
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        env:
+          AUTOMERGE_MODE: ${{ vars.DEPENDABOT_AUTOMERGE_MODE || 'off' }}
         with:
           script: |
-            const pullNumber = context.payload.pull_request.number;
-            const title = context.payload.pull_request.title;
+            const mode = process.env.AUTOMERGE_MODE.toLowerCase();
+            if (!['off', 'observe', 'active'].includes(mode)) {
+              core.setFailed(`Invalid DEPENDABOT_AUTOMERGE_MODE: ${mode}`);
+              return;
+            }
 
-            await github.rest.pulls.merge({
+            const pullNumber = context.payload.pull_request.number;
+            const expectedRepository = `${context.repo.owner}/${context.repo.repo}`;
+            const conventionalTitle = /^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?!?: .+/;
+
+            const validate = (pull) => {
+              const labels = new Set(pull.labels.map((label) => label.name));
+              const failures = [];
+              if (pull.user.login !== 'dependabot[bot]') failures.push('author is not dependabot[bot]');
+              if (pull.base.ref !== 'dev') failures.push('base branch is not dev');
+              if (pull.base.repo.full_name !== expectedRepository) failures.push('base repository does not match');
+              if (pull.head.repo?.full_name !== expectedRepository) failures.push('head repository does not match');
+              if (pull.state !== 'open') failures.push('pull request is not open');
+              if (pull.draft) failures.push('pull request is a draft');
+              if (!labels.has('automerge')) failures.push('automerge label is missing');
+              if (!conventionalTitle.test(pull.title)) failures.push('title is not a Conventional Commit title');
+              return failures;
+            };
+
+            const eventPull = context.payload.pull_request;
+            const eventFailures = validate(eventPull);
+            if (eventFailures.length > 0) {
+              core.notice(`Dependabot auto-merge is ineligible: ${eventFailures.join('; ')}`);
+              return;
+            }
+
+            if (mode === 'off') {
+              core.notice('Dependabot auto-merge is disabled.');
+              return;
+            }
+            if (mode === 'observe') {
+              core.notice(`Dependabot PR #${pullNumber} is eligible for native auto-merge.`);
+              return;
+            }
+
+            const { data: repository } = await github.rest.repos.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            if (!repository.allow_auto_merge) {
+              core.setFailed('Repository native auto-merge is disabled.');
+              return;
+            }
+
+            const { data: currentPull } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: pullNumber,
-              merge_method: 'squash',
-              commit_title: `${title} (#${pullNumber})`,
             });
+            const currentFailures = validate(currentPull);
+            if (currentPull.head.sha !== eventPull.head.sha) {
+              currentFailures.push(`head changed from ${eventPull.head.sha} to ${currentPull.head.sha}`);
+            }
+            if (currentFailures.length > 0) {
+              core.setFailed(`Refusing stale or ineligible auto-merge: ${currentFailures.join('; ')}`);
+              return;
+            }
 
-            console.log('Dependabot PR merged successfully.');
+            await github.graphql(
+              `mutation EnableAutoMerge(
+                $pullRequestId: ID!
+                $expectedHeadOid: GitObjectID!
+                $commitHeadline: String!
+              ) {
+                enablePullRequestAutoMerge(input: {
+                  pullRequestId: $pullRequestId
+                  expectedHeadOid: $expectedHeadOid
+                  mergeMethod: MERGE
+                  commitHeadline: $commitHeadline
+                }) {
+                  pullRequest {
+                    number
+                    autoMergeRequest { enabledAt mergeMethod }
+                  }
+                }
+              }`,
+              {
+                pullRequestId: currentPull.node_id,
+                expectedHeadOid: currentPull.head.sha,
+                commitHeadline: `${currentPull.title} (#${pullNumber})`,
+              },
+            );
+
+            core.info(`Native auto-merge registered for Dependabot PR #${pullNumber} at ${currentPull.head.sha}.`);

--- a/.github/workflows/block-master-prs.yml
+++ b/.github/workflows/block-master-prs.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Close PR and Leave Comment
         if: steps.check.outputs.is_allowed == 'false'
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           script: |
             const message = `

--- a/.github/workflows/build-dockerhub.yml
+++ b/.github/workflows/build-dockerhub.yml
@@ -82,9 +82,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          token: ${{ github.event_name == 'pull_request' && github.token || secrets.PAT_TOKEN || github.token }}
+          token: ${{ secrets.PAT_TOKEN || github.token }}
           fetch-depth: 0
-          persist-credentials: ${{ github.event_name != 'pull_request' }}
 
       - name: Resolve build metadata
         id: metadata
@@ -279,9 +278,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          token: ${{ github.event_name == 'pull_request' && github.token || secrets.PAT_TOKEN || github.token }}
+          token: ${{ secrets.PAT_TOKEN || github.token }}
           fetch-depth: 0
-          persist-credentials: ${{ github.event_name != 'pull_request' }}
 
       - name: Download dependency snapshot
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/build-dockerhub.yml
+++ b/.github/workflows/build-dockerhub.yml
@@ -8,10 +8,6 @@ on:
       - 'README.md'
       - 'README-*.md'
       - 'docker-compose.yml'
-  pull_request:
-    branches:
-      - master
-      - dev
   workflow_dispatch:
   workflow_call:
 permissions:
@@ -72,7 +68,7 @@ jobs:
     name: "🔧 Prepare Metadata"
     runs-on: ubuntu-latest
     needs: source-head
-    if: needs.source-head.outputs.current == 'true' && github.actor != 'dependabot[bot]' && (github.ref != 'refs/heads/dev' || (!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[ci skip]')))
+    if: needs.source-head.outputs.current == 'true' && (github.ref != 'refs/heads/dev' || (!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[ci skip]')))
     outputs:
       sha: ${{ steps.metadata.outputs.sha }}
       sha_short: ${{ steps.metadata.outputs.sha_short }}
@@ -86,8 +82,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          token: ${{ secrets.PAT_TOKEN || github.token }}
+          token: ${{ github.event_name == 'pull_request' && github.token || secrets.PAT_TOKEN || github.token }}
           fetch-depth: 0
+          persist-credentials: ${{ github.event_name != 'pull_request' }}
 
       - name: Resolve build metadata
         id: metadata
@@ -245,6 +242,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
@@ -280,8 +279,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          token: ${{ secrets.PAT_TOKEN || github.token }}
+          token: ${{ github.event_name == 'pull_request' && github.token || secrets.PAT_TOKEN || github.token }}
           fetch-depth: 0
+          persist-credentials: ${{ github.event_name != 'pull_request' }}
 
       - name: Download dependency snapshot
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,10 +2,12 @@ name: "CodeQL"
 
 on:
   workflow_dispatch:
+  workflow_call:
   push:
     branches: [ "dev" ]
-  pull_request:
-    branches: [ "dev", "master" ]
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -56,7 +58,7 @@ jobs:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     needs: source-head
-    if: needs.source-head.outputs.current == 'true' && github.actor != 'dependabot[bot]'
+    if: needs.source-head.outputs.current == 'true'
     permissions:
       actions: read
       contents: read
@@ -78,15 +80,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
-        token: ${{ secrets.PAT_TOKEN || github.token }}
+        persist-credentials: false
 
     # [OPTIMIZATION] Cache build artifacts (QuickJSPP & LibCron)
     - name: Cache Build Artifacts
-      if: matrix.language == 'c-cpp'
+      if: matrix.language == 'c-cpp' && github.event_name != 'pull_request'
       id: cache-cpp-deps
-      uses: actions/cache@v5
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
       with:
         path: |
           /usr/lib/quickjs
@@ -239,7 +241,7 @@ jobs:
         cd ..
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@988661ebb5e81487b3fb31b2185d2856c0a10679 # v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -255,6 +257,6 @@ jobs:
         cmake --build build -j"$(nproc)"
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@988661ebb5e81487b3fb31b2185d2856c0a10679 # v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/manage-inactive-issues.yml
+++ b/.github/workflows/manage-inactive-issues.yml
@@ -29,13 +29,13 @@ jobs:
       INACTIVE_ISSUE_DRY_RUN: ${{ inputs.dry_run || 'false' }}
     steps:
       - name: Check out repository automation
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Test issue management rules
         run: node --test .github/scripts/manage-inactive-issues.test.cjs
 
       - name: Close issues without replies for fourteen days
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           script: |
             const manageInactiveIssues = require('./.github/scripts/manage-inactive-issues.cjs');

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,51 @@
+name: PR Validation
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - master
+
+permissions: {}
+
+concurrency:
+  group: pr-validation-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build and test
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-dockerhub.yml
+
+  codeql:
+    name: CodeQL
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
+    uses: ./.github/workflows/codeql.yml
+
+  gate:
+    name: PR Gate
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - codeql
+    permissions: {}
+    steps:
+      - name: Require all PR validation workflows
+        shell: bash
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+          CODEQL_RESULT: ${{ needs.codeql.result }}
+        run: |
+          set -euo pipefail
+          if [ "$BUILD_RESULT" != "success" ] || [ "$CODEQL_RESULT" != "success" ]; then
+            echo "::error::PR validation failed: build=$BUILD_RESULT codeql=$CODEQL_RESULT"
+            exit 1
+          fi
+          echo "PR validation succeeded."

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -13,11 +13,137 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build and test
+  source-validation:
+    name: Source validation
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-    uses: ./.github/workflows/build-dockerhub.yml
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: bridge/go.mod
+          cache-dependency-path: bridge/go.sum
+
+      - name: Run maintained Python regressions
+        run: python3 -m unittest discover -s tests -p 'test_*.py' -v
+
+      - name: Run Go bridge regressions
+        working-directory: bridge
+        run: go test -mod=readonly ./...
+
+      - name: Validate workflow and delivery scripts
+        run: |
+          set -euo pipefail
+          go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+          bash -n scripts/ci/*.sh
+          bash tests/ci_delivery_scripts_test.sh
+
+  candidate:
+    name: Build and smoke test candidate
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve build metadata
+        id: metadata
+        run: python3 scripts/ci/build_metadata.py --github-output "$GITHUB_OUTPUT"
+
+      - name: Validate and activate dependency snapshot
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/dependency_snapshot.py check
+          python3 scripts/ci/dependency_snapshot.py emit --github-env "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Prepare Docker build args
+        id: docker_args
+        env:
+          THREADS: "16"
+          SHA: ${{ steps.metadata.outputs.sha }}
+          VERSION: ${{ steps.metadata.outputs.version }}
+          BUILD_DATE: ${{ steps.metadata.outputs.build_date }}
+          REFRESH_GO_DEPS: "false"
+          REFRESH_HEADERS: "false"
+          BUILD_TESTS: "true"
+        run: |
+          {
+            echo 'args<<EOF'
+            bash scripts/ci/docker-build-args.sh
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build candidate image
+        env:
+          BUILD_ARGS: ${{ steps.docker_args.outputs.args }}
+        run: |
+          bash scripts/ci/build-candidate-image.sh \
+            amd64 \
+            ./Dockerfile \
+            linux/amd64 \
+            subconverter-alpine \
+            pull_request \
+            pr \
+            "${{ steps.metadata.outputs.version }}"
+
+      - name: Export CI artifacts from the candidate build
+        env:
+          BUILD_ARGS: ${{ steps.docker_args.outputs.args }}
+        run: |
+          bash scripts/ci/export-ci-image.sh \
+            ./Dockerfile \
+            subconverter-temp:amd64-builder \
+            linux/amd64
+
+      - name: Extract builder output
+        env:
+          EXTRACT_GENERATED: "true"
+        run: bash scripts/ci/extract-builder-output.sh subconverter-temp:amd64-builder shared
+
+      - name: Check bridge size budget
+        run: python3 scripts/ci/check_file_size.py --budget bridge-linux-amd64 build/bridge-output/libmihomo.so
+
+      - name: Verify frozen dependency and generated inputs
+        run: |
+          set -euo pipefail
+          paths=(
+            scripts/ci/dependencies.lock.json
+            bridge/go.mod bridge/go.sum bridge/libmihomo.h
+            bridge/mihomo_capabilities.json bridge/proxy_validation_generated.go
+            src/parser/mihomo_schemes.h src/parser/param_compat.h
+            include/httplib.h include/nlohmann/json.hpp include/inja.hpp
+            include/jpcre2.hpp include/quickjspp.hpp
+            include/libcron include/date include/toml.hpp include/toml11
+          )
+          if [ -n "$(git status --porcelain -- "${paths[@]}")" ]; then
+            git status --short -- "${paths[@]}"
+            echo "::error::Frozen dependency/generated inputs are stale. Refresh and commit them on dev."
+            exit 1
+          fi
+
+      - name: Smoke test candidate image
+        timeout-minutes: 5
+        uses: ./.github/actions/smoke-docker-image
+        with:
+          image: subconverter-extended:amd64-ci
+          platform: linux/amd64
+          expected-version: ${{ steps.metadata.outputs.version }}
+          expected-revision: ${{ steps.metadata.outputs.sha }}
+          expected-build-date: ${{ steps.metadata.outputs.build_date }}
 
   codeql:
     name: CodeQL
@@ -33,19 +159,23 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     needs:
-      - build
+      - source-validation
+      - candidate
       - codeql
     permissions: {}
     steps:
       - name: Require all PR validation workflows
         shell: bash
         env:
-          BUILD_RESULT: ${{ needs.build.result }}
+          SOURCE_RESULT: ${{ needs.source-validation.result }}
+          CANDIDATE_RESULT: ${{ needs.candidate.result }}
           CODEQL_RESULT: ${{ needs.codeql.result }}
         run: |
           set -euo pipefail
-          if [ "$BUILD_RESULT" != "success" ] || [ "$CODEQL_RESULT" != "success" ]; then
-            echo "::error::PR validation failed: build=$BUILD_RESULT codeql=$CODEQL_RESULT"
+          if [ "$SOURCE_RESULT" != "success" ] || \
+             [ "$CANDIDATE_RESULT" != "success" ] || \
+             [ "$CODEQL_RESULT" != "success" ]; then
+            echo "::error::PR validation failed: source=$SOURCE_RESULT candidate=$CANDIDATE_RESULT codeql=$CODEQL_RESULT"
             exit 1
           fi
           echo "PR validation succeeded."


### PR DESCRIPTION
## Summary
- Route dev and master pull requests through one read-only PR Validation workflow with a stable PR Gate result.
- Run source regressions, an amd64 candidate build, frozen-input verification, container smoke tests, and CodeQL before the gate can pass.
- Keep PAT-backed checkout, registry login, image publication, and release jobs outside the pull-request path; the PR candidate uses only contents: read and persists no credentials.
- Stop excluding Dependabot from Build/CodeQL and replace immediate squash merges with a fail-closed native MERGE auto-merge registrar.
- Pin the remaining floating Actions references to verified commit SHAs.

## Activation boundary
- DEPENDABOT_AUTOMERGE_MODE defaults to off.
- This PR does not enable repository auto-merge and does not change branch rulesets.
- Phase 2 must require PR Gate on dev before the registrar can be moved through observe to active.

## Validation
- actionlint 1.7.12
- git diff --check
- Python unittest suite: 37 passed
- Go bridge tests: passed
- inactive issue rules: 9 passed
- CI delivery script contract: passed in an isolated Linux/LF clone at both implementation commits