### PR TITLE
chore(dependabot): set deterministic update schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     target-branch: "dev"
     schedule:
       interval: "daily"
+      time: "08:00"
+      timezone: "Asia/Shanghai"
     open-pull-requests-limit: 10
     rebase-strategy: "auto"
     groups:
@@ -23,6 +25,8 @@ updates:
     target-branch: "dev"
     schedule:
       interval: "daily"
+      time: "08:00"
+      timezone: "Asia/Shanghai"
     open-pull-requests-limit: 10
     rebase-strategy: "auto"
     groups:
@@ -40,6 +44,8 @@ updates:
     target-branch: "dev"
     schedule:
       interval: "daily"
+      time: "08:00"
+      timezone: "Asia/Shanghai"
     open-pull-requests-limit: 10
     rebase-strategy: "auto"
     groups:


### PR DESCRIPTION
## Summary
- schedule GitHub Actions, Docker, and Go dependency checks at 08:00 Asia/Shanghai
- keep all Dependabot update PRs targeted at dev
- make the default-branch config change observable and deterministic

## Validation
- parsed `.github/dependabot.yml` with PyYAML
- asserted all three ecosystems use the expected interval, time, and timezone
- `git diff --check`