### PR TITLE
chore(dependabot): set deterministic update schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     target-branch: "dev"
     schedule:
       interval: "daily"
+      time: "08:00"
+      timezone: "Asia/Shanghai"
     open-pull-requests-limit: 10
     rebase-strategy: "auto"
     groups:
@@ -23,6 +25,8 @@ updates:
     target-branch: "dev"
     schedule:
       interval: "daily"
+      time: "08:00"
+      timezone: "Asia/Shanghai"
     open-pull-requests-limit: 10
     rebase-strategy: "auto"
     groups:
@@ -40,6 +44,8 @@ updates:
     target-branch: "dev"
     schedule:
       interval: "daily"
+      time: "08:00"
+      timezone: "Asia/Shanghai"
     open-pull-requests-limit: 10
     rebase-strategy: "auto"
     groups:


### PR DESCRIPTION
## Summary
- mirror the validated Dependabot schedule from dev onto the default branch
- force GitHub to re-ingest `.github/dependabot.yml`
- keep all generated dependency PRs targeted at dev

## Scope guard
- config-only: `.github/dependabot.yml`
- no dev code synchronization, release, tag, image publication, or deployment
- master still has stale required check names; this PR is intended for an exact-diff administrator merge after its available policy check completes

## Validation
- candidate is byte-equivalent to `origin/dev:.github/dependabot.yml`
- YAML parse and three-ecosystem schedule assertions passed
- `git diff --check`