### PR TITLE
fix(dependabot): rely on native auto-merge mutation

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -61,15 +61,6 @@ jobs:
               return;
             }
 
-            const { data: repository } = await github.rest.repos.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            });
-            if (!repository.allow_auto_merge) {
-              core.setFailed('Repository native auto-merge is disabled.');
-              return;
-            }
-
             const { data: currentPull } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Summary
- remove the REST repository-setting preflight from the native auto-merge path
- rely on the authoritative `enablePullRequestAutoMerge` mutation to report a truly disabled repository
- preserve every eligibility, stale-head, merge-method, and permission guard

## Live canary evidence
- active attempt 2 of run 31955942125 saw `allow_auto_merge=false` with the minimal Actions token
- the same repository currently returns `allow_auto_merge=true` to the administrator REST API and `autoMergeAllowed=true` through GraphQL
- the permission-shaped REST field caused a false negative before the mutation ran

## Validation
- actionlint
- `git diff --check`
- single workflow file, 9-line deletion