### PR TITLE
fix(dependabot): rely on native auto-merge mutation

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -61,15 +61,6 @@ jobs:
               return;
             }
 
-            const { data: repository } = await github.rest.repos.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            });
-            if (!repository.allow_auto_merge) {
-              core.setFailed('Repository native auto-merge is disabled.');
-              return;
-            }
-
             const { data: currentPull } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Summary
- mirror the dev fix that removes a permission-shaped REST false negative
- let the native GraphQL mutation be the authoritative repository auto-merge check
- preserve the hardened default-branch workflow used by `pull_request_target`

## Live canary evidence
- active attempt 2 of run 31955942125 failed before mutation because the workflow token saw `allow_auto_merge=false`
- administrator REST and GraphQL currently confirm native auto-merge is enabled

## Scope and validation
- exact workflow content matches the dev fix candidate
- actionlint and `git diff --check`
- single file, 9-line deletion