### PR TITLE
fix(dependabot): grant native merge permission

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -7,7 +7,8 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
 
 permissions:
-  contents: read
+  # Required by GitHub's native auto-merge API; no pull request code is checked out.
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Summary
- grant the workflow token the repository write permission required by GitHub's native auto-merge API
- document why the permission cannot be reduced to read
- keep the job free of checkout, PR code execution, direct merge calls, and floating actions

## Official and live evidence
- GitHub's Dependabot auto-merge example requires both `contents: write` and `pull-requests: write`
- fresh active run 31956668046 reached `enablePullRequestAutoMerge` but failed with `Resource not accessible by integration` under `contents: read`

## Validation
- actionlint and `git diff --check`
- no checkout, `pulls.merge`, or squash path
- single workflow file, 2 additions / 1 deletion