### PR TITLE
fix(dependabot): grant native merge permission

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -7,7 +7,8 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
 
 permissions:
-  contents: read
+  # Required by GitHub's native auto-merge API; no pull request code is checked out.
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Summary
- mirror the dev permission fix into the default-branch workflow used by `pull_request_target`
- grant only the write permission required by GitHub native auto-merge
- keep the job free of checkout, untrusted-code execution, and direct merge calls

## Official and live evidence
- GitHub's documented Dependabot auto-merge workflow uses `contents: write` plus `pull-requests: write`
- run 31956668046 failed at `enablePullRequestAutoMerge` with `Resource not accessible by integration` under `contents: read`

## Scope and validation
- exact workflow content matches the dev candidate
- actionlint and `git diff --check`
- single file, 2 additions / 1 deletion