### PR TITLE
fix(dependabot): preserve post-merge validation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
       actions:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "ci"
@@ -33,6 +36,9 @@ updates:
       docker:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "docker"
@@ -52,6 +58,9 @@ updates:
       go-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "go"

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -7,9 +7,8 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
 
 permissions:
-  # Required by GitHub's native auto-merge API; no pull request code is checked out.
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 jobs:
   auto-merge:
@@ -21,6 +20,9 @@ jobs:
         env:
           AUTOMERGE_MODE: ${{ vars.DEPENDABOT_AUTOMERGE_MODE || 'off' }}
         with:
+          # GITHUB_TOKEN-created events are recursion-suppressed after it enables auto-merge.
+          # The existing PAT keeps the resulting merge commit on the normal push CI path.
+          github-token: ${{ secrets.PAT_TOKEN }}
           script: |
             const mode = process.env.AUTOMERGE_MODE.toLowerCase();
             if (!['off', 'observe', 'active'].includes(mode)) {
@@ -42,6 +44,8 @@ jobs:
               if (pull.state !== 'open') failures.push('pull request is not open');
               if (pull.draft) failures.push('pull request is a draft');
               if (!labels.has('automerge')) failures.push('automerge label is missing');
+              if (!labels.has('minor') && !labels.has('patch')) failures.push('update is not minor or patch');
+              if (labels.has('major')) failures.push('major updates require manual review');
               if (!conventionalTitle.test(pull.title)) failures.push('title is not a Conventional Commit title');
               return failures;
             };


### PR DESCRIPTION
## Summary
- use the existing PAT only for the no-checkout native auto-merge API call so the resulting merge commit triggers normal push workflows
- keep the workflow-scoped GITHUB_TOKEN read-only
- auto-merge only Dependabot minor/patch updates; major updates remain manual
- group only minor/patch Dependabot updates

## Validation
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`n- git diff --cached --check`n- live verification will require PR Gate and a real Dependabot canary
