### PR TITLE
fix(dependabot): merge only validated heads

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,27 +1,32 @@
-name: Auto-merge Dependabot PRs
+name: Merge validated Dependabot PRs
 
 on:
-  pull_request_target:
-    branches:
-      - dev
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
+  workflow_run:
+    workflows:
+      - PR Validation
+    types:
+      - completed
 
 permissions:
+  actions: read
   contents: read
   pull-requests: read
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' && github.event.pull_request.user.login == 'dependabot[bot]'
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]'
     steps:
-      - name: Register native auto-merge
+      - name: Merge the validated Dependabot head
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           AUTOMERGE_MODE: ${{ vars.DEPENDABOT_AUTOMERGE_MODE || 'off' }}
         with:
-          # GITHUB_TOKEN-created events are recursion-suppressed after it enables auto-merge.
-          # The existing PAT keeps the resulting merge commit on the normal push CI path.
+          # No pull request code or artifacts are consumed. The existing PAT makes the
+          # resulting merge commit follow the normal push CI path.
           github-token: ${{ secrets.PAT_TOKEN }}
           script: |
             const mode = process.env.AUTOMERGE_MODE.toLowerCase();
@@ -30,79 +35,95 @@ jobs:
               return;
             }
 
-            const pullNumber = context.payload.pull_request.number;
+            const run = context.payload.workflow_run;
             const expectedRepository = `${context.repo.owner}/${context.repo.repo}`;
             const conventionalTitle = /^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?!?: .+/;
-
-            const validate = (pull) => {
-              const labels = new Set(pull.labels.map((label) => label.name));
-              const failures = [];
-              if (pull.user.login !== 'dependabot[bot]') failures.push('author is not dependabot[bot]');
-              if (pull.base.ref !== 'dev') failures.push('base branch is not dev');
-              if (pull.base.repo.full_name !== expectedRepository) failures.push('base repository does not match');
-              if (pull.head.repo?.full_name !== expectedRepository) failures.push('head repository does not match');
-              if (pull.state !== 'open') failures.push('pull request is not open');
-              if (pull.draft) failures.push('pull request is a draft');
-              if (!labels.has('automerge')) failures.push('automerge label is missing');
-              if (!labels.has('minor') && !labels.has('patch')) failures.push('update is not minor or patch');
-              if (labels.has('major')) failures.push('major updates require manual review');
-              if (!conventionalTitle.test(pull.title)) failures.push('title is not a Conventional Commit title');
-              return failures;
-            };
-
-            const eventPull = context.payload.pull_request;
-            const eventFailures = validate(eventPull);
-            if (eventFailures.length > 0) {
-              core.notice(`Dependabot auto-merge is ineligible: ${eventFailures.join('; ')}`);
-              return;
-            }
 
             if (mode === 'off') {
               core.notice('Dependabot auto-merge is disabled.');
               return;
             }
-            if (mode === 'observe') {
-              core.notice(`Dependabot PR #${pullNumber} is eligible for native auto-merge.`);
+            if (
+              run.name !== 'PR Validation' ||
+              run.path !== '.github/workflows/pr-validation.yml' ||
+              run.event !== 'pull_request' ||
+              run.conclusion !== 'success'
+            ) {
+              core.setFailed('Refusing an unexpected validation workflow result.');
+              return;
+            }
+            if (run.actor.login !== 'dependabot[bot]') {
+              core.setFailed(`Refusing validation initiated by ${run.actor.login}.`);
+              return;
+            }
+            if (run.head_repository?.full_name !== expectedRepository) {
+              core.setFailed('Validation head repository does not match.');
+              return;
+            }
+            const pullRequests = run.pull_requests ?? [];
+            if (pullRequests.length !== 1) {
+              core.setFailed(`Expected one pull request, found ${pullRequests.length}.`);
               return;
             }
 
+            const pullNumber = pullRequests[0].number;
+            const expectedHead = run.head_sha;
             const { data: currentPull } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: pullNumber,
             });
-            const currentFailures = validate(currentPull);
-            if (currentPull.head.sha !== eventPull.head.sha) {
-              currentFailures.push(`head changed from ${eventPull.head.sha} to ${currentPull.head.sha}`);
+
+            const labels = new Set(currentPull.labels.map((label) => label.name));
+            const failures = [];
+            if (currentPull.user.login !== 'dependabot[bot]') failures.push('author is not dependabot[bot]');
+            if (currentPull.base.ref !== 'dev') failures.push('base branch is not dev');
+            if (currentPull.base.repo.full_name !== expectedRepository) failures.push('base repository does not match');
+            if (currentPull.head.repo?.full_name !== expectedRepository) failures.push('head repository does not match');
+            if (currentPull.head.sha !== expectedHead) failures.push(`head changed from ${expectedHead} to ${currentPull.head.sha}`);
+            if (currentPull.state !== 'open') failures.push('pull request is not open');
+            if (currentPull.draft) failures.push('pull request is a draft');
+            if (!labels.has('automerge')) failures.push('automerge label is missing');
+            if (!labels.has('minor') && !labels.has('patch')) failures.push('update is not minor or patch');
+            if (labels.has('major')) failures.push('major updates require manual review');
+            if (!conventionalTitle.test(currentPull.title)) failures.push('title is not a Conventional Commit title');
+
+            const { data: checks } = await github.rest.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: expectedHead,
+              check_name: 'PR Gate',
+              filter: 'latest',
+              per_page: 100,
+            });
+            const gate = checks.check_runs.find((check) =>
+              check.name === 'PR Gate' &&
+              check.app?.id === 15368 &&
+              check.status === 'completed' &&
+              check.conclusion === 'success'
+            );
+            if (!gate) failures.push('exact-head PR Gate is not successful');
+
+            if (failures.length > 0) {
+              core.setFailed(`Refusing stale or ineligible Dependabot merge: ${failures.join('; ')}`);
+              return;
             }
-            if (currentFailures.length > 0) {
-              core.setFailed(`Refusing stale or ineligible auto-merge: ${currentFailures.join('; ')}`);
+            if (mode === 'observe') {
+              core.notice(`Dependabot PR #${pullNumber} at ${expectedHead} is eligible after PR Gate.`);
               return;
             }
 
-            await github.graphql(
-              `mutation EnableAutoMerge(
-                $pullRequestId: ID!
-                $expectedHeadOid: GitObjectID!
-                $commitHeadline: String!
-              ) {
-                enablePullRequestAutoMerge(input: {
-                  pullRequestId: $pullRequestId
-                  expectedHeadOid: $expectedHeadOid
-                  mergeMethod: MERGE
-                  commitHeadline: $commitHeadline
-                }) {
-                  pullRequest {
-                    number
-                    autoMergeRequest { enabledAt mergeMethod }
-                  }
-                }
-              }`,
-              {
-                pullRequestId: currentPull.node_id,
-                expectedHeadOid: currentPull.head.sha,
-                commitHeadline: `${currentPull.title} (#${pullNumber})`,
-              },
-            );
+            const { data: merge } = await github.rest.pulls.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullNumber,
+              sha: expectedHead,
+              merge_method: 'merge',
+              commit_title: `${currentPull.title} (#${pullNumber})`,
+            });
+            if (!merge.merged) {
+              core.setFailed(`GitHub refused Dependabot PR #${pullNumber}: ${merge.message}`);
+              return;
+            }
 
-            core.info(`Native auto-merge registered for Dependabot PR #${pullNumber} at ${currentPull.head.sha}.`);
+            core.info(`Merged validated Dependabot PR #${pullNumber} as ${merge.sha}.`);


### PR DESCRIPTION
Configuration-only default-branch synchronization of the validated Dependabot merge workflow.

The workflow consumes no PR checkout, artifact, cache, or executable content. It acts only after the canonical PR Validation workflow succeeds, then rechecks the bot identity, exact head, labels, semantic update class, and GitHub Actions PR Gate before requesting a normal MERGE through the existing PAT.

No product code, release, tag, or deployment changes.