### PR TITLE
fix(dependabot): remove manual update gating

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,6 @@ updates:
       actions:
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"
     labels:
       - "dependencies"
       - "ci"
@@ -36,9 +33,6 @@ updates:
       docker:
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"
     labels:
       - "dependencies"
       - "docker"
@@ -58,9 +52,6 @@ updates:
       go-dependencies:
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"
     labels:
       - "dependencies"
       - "go"

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -84,8 +84,6 @@ jobs:
             if (currentPull.state !== 'open') failures.push('pull request is not open');
             if (currentPull.draft) failures.push('pull request is a draft');
             if (!labels.has('automerge')) failures.push('automerge label is missing');
-            if (!labels.has('minor') && !labels.has('patch')) failures.push('update is not minor or patch');
-            if (labels.has('major')) failures.push('major updates require manual review');
             if (!conventionalTitle.test(currentPull.title)) failures.push('title is not a Conventional Commit title');
 
             const { data: checks } = await github.rest.checks.listForRef({


### PR DESCRIPTION
## Summary
- group major, minor, patch, and SHA-only dependency updates by ecosystem
- remove version-class checks that required manual review
- retain exact-head PR Gate, trusted-author, repository, branch, label, and Conventional Commit checks

## Validation
- git diff --check
- actionlint v1.7.12

No product code, release, tag, or deployment changes.