### PR TITLE
fix(dependabot): remove manual update gating

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,6 @@ updates:
       actions:
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"
     labels:
       - "dependencies"
       - "ci"
@@ -36,9 +33,6 @@ updates:
       docker:
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"
     labels:
       - "dependencies"
       - "docker"
@@ -58,9 +52,6 @@ updates:
       go-dependencies:
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"
     labels:
       - "dependencies"
       - "go"

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -84,8 +84,6 @@ jobs:
             if (currentPull.state !== 'open') failures.push('pull request is not open');
             if (currentPull.draft) failures.push('pull request is a draft');
             if (!labels.has('automerge')) failures.push('automerge label is missing');
-            if (!labels.has('minor') && !labels.has('patch')) failures.push('update is not minor or patch');
-            if (labels.has('major')) failures.push('major updates require manual review');
             if (!conventionalTitle.test(currentPull.title)) failures.push('title is not a Conventional Commit title');
 
             const { data: checks } = await github.rest.checks.listForRef({


### PR DESCRIPTION
## Summary
- apply the unattended Dependabot grouping and merge policy on the default branch
- allow all update classes after fully automated PR Validation
- retain exact-head and trusted-author safety checks

## Scope
Configuration-only synchronization required because Dependabot and workflow_run use the default-branch definitions. No product code, tag, Release, or deployment changes.

## Validation
- git diff --check
- actionlint v1.7.12