### PR TITLE
feat(api): expose conversion capabilities

### DIFF
--- a/src/handler/interfaces.cpp
+++ b/src/handler/interfaces.cpp
@@ -9,6 +9,7 @@
 #include <ctime>
 #include <exception>
 #include <iostream>
+#include <initializer_list>
 #include <limits>
 #include <memory>
 #include <map>
@@ -81,6 +82,7 @@ static string_icase_map buildSubscriptionRequestHeaders() {
 #include "utils/system.h"
 #include "utils/urlencode.h"
 #include "utils/yamlcpp_extra.h"
+#include "version.h"
 #include "webget.h"
 
 extern WebServer webServer;
@@ -198,6 +200,131 @@ static std::string supportedTargets(const std::string &separator) {
     result += target.name;
   }
   return result;
+}
+
+std::string getSubCapabilities(RESPONSE_CALLBACK_ARGS) {
+  (void)request;
+  response.headers["Cache-Control"] = "no-store, max-age=0";
+  response.headers["X-Content-Type-Options"] = "nosniff";
+  response.headers["X-Robots-Tag"] =
+      "noindex, nofollow, noarchive, nosnippet";
+
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+  auto write_string = [&](const char *key, const std::string &value) {
+    writer.Key(key);
+    writer.String(value.c_str());
+  };
+  auto write_string_array = [&](const char *key,
+                                std::initializer_list<const char *> values) {
+    writer.Key(key);
+    writer.StartArray();
+    for (const char *value : values)
+      writer.String(value);
+    writer.EndArray();
+  };
+  auto write_constraint = [&](const char *name,
+                              std::initializer_list<const char *> targets) {
+    writer.Key(name);
+    writer.StartArray();
+    for (const char *target : targets)
+      writer.String(target);
+    writer.EndArray();
+  };
+  auto write_modifier = [&](const char *name, const char *type,
+                            std::initializer_list<const char *> targets) {
+    writer.StartObject();
+    writer.Key("name");
+    writer.String(name);
+    writer.Key("type");
+    writer.String(type);
+    writer.Key("targets");
+    writer.StartArray();
+    for (const char *target : targets)
+      writer.String(target);
+    writer.EndArray();
+    writer.EndObject();
+  };
+
+  writer.StartObject();
+  writer.Key("schema_version");
+  writer.Uint(1);
+  writer.Key("backend");
+  writer.StartObject();
+  write_string("family", "SubConverter-Extended");
+  write_string("version", VERSION);
+  write_string("revision", BUILD_ID);
+  writer.EndObject();
+
+  writer.Key("targets");
+  writer.StartArray();
+  writer.StartObject();
+  write_string("name", "auto");
+  write_string("parser", "user-agent");
+  write_string("remote_mode", "auto");
+  writer.Key("simple_subscription");
+  writer.Bool(false);
+  writer.EndObject();
+  for (const TargetDescriptor &target : kTargetDescriptors) {
+    writer.StartObject();
+    write_string("name", target.name);
+    write_string("parser", nodeParserModeName(target.parser_mode));
+    write_string("remote_mode",
+                 remoteSubscriptionModeName(target.remote_subscription_mode));
+    writer.Key("simple_subscription");
+    writer.Bool(target.simple_subscription);
+    writer.EndObject();
+  }
+  writer.EndArray();
+
+  writer.Key("query_parameters");
+  writer.StartObject();
+  write_string_array(
+      "recognized",
+      {"target", "url", "ver", "new_name", "group", "upload_path",
+       "include", "exclude", "groups", "ruleset", "config", "dev_id",
+       "filename", "interval", "strict", "rename", "filter_script",
+       "upload", "emoji", "add_emoji", "remove_emoji", "append_type",
+       "tfo", "udp", "list", "sort", "sort_script", "script",
+       "insert", "scv", "fdn", "expand", "append_info", "prepend",
+       "classic", "tls13", "provider_proxy_direct", "provider_headers",
+       "explain", "profile_data", "token"});
+  write_string_array("ignored",
+                     {"groups", "ruleset", "filter_script", "token"});
+  write_string_array("internal",
+                     {"upload", "upload_path", "profile_data", "token",
+                      "filter_script"});
+  writer.Key("forced");
+  writer.StartObject();
+  writer.Key("new_name");
+  writer.Bool(true);
+  writer.EndObject();
+  writer.Key("target_constraints");
+  writer.StartObject();
+  write_constraint("ver", {"surge"});
+  write_constraint("dev_id", {"quanx"});
+  write_constraint("provider_headers", {"clash", "stash"});
+  write_constraint("provider_proxy_direct", {"clash", "clashr"});
+  write_constraint("script", {"clash", "clashr"});
+  write_constraint("classic", {"clash", "clashr"});
+  write_constraint("new_name", {"clash", "clashr"});
+  writer.EndObject();
+  writer.EndObject();
+
+  writer.Key("source_modifiers");
+  writer.StartArray();
+  write_modifier("tag", "string",
+                 {"clash", "clashr", "surge", "quanx", "loon",
+                  "surfboard", "stash"});
+  write_modifier("provider", "string",
+                 {"clash", "clashr", "surge", "quanx", "loon",
+                  "surfboard", "stash"});
+  write_modifier("interval", "integer",
+                 {"clash", "clashr", "surge", "quanx", "stash"});
+  write_modifier("proxy_direct", "boolean", {"clash", "clashr"});
+  writer.EndArray();
+  writer.EndObject();
+  return buffer.GetString();
 }
 
 static std::string trimProviderUserAgentCandidate(const std::string &ua) {

--- a/src/handler/interfaces.h
+++ b/src/handler/interfaces.h
@@ -22,6 +22,7 @@ std::string convertRuleset(const std::string &content, int type);
 
 std::string getProfile(RESPONSE_CALLBACK_ARGS);
 std::string getRuleset(RESPONSE_CALLBACK_ARGS);
+std::string getSubCapabilities(RESPONSE_CALLBACK_ARGS);
 
 std::string subconverter(RESPONSE_CALLBACK_ARGS);
 std::string subconverterTracked(RESPONSE_CALLBACK_ARGS);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -371,6 +371,9 @@ int main(int argc, char *argv[]) {
 
   webServer.append_response("GET", "/version", "text/html; charset=utf-8",
                             version_page::page);
+  webServer.append_response("GET", "/capabilities",
+                            "application/json; charset=utf-8",
+                            getSubCapabilities);
   webServer.append_response("GET", "/inspect", "text/html; charset=utf-8",
                             inspect_page::page);
   if (global.statisticsEnabled) {
@@ -387,6 +390,7 @@ int main(int argc, char *argv[]) {
       [](RESPONSE_CALLBACK_ARGS) -> std::string {
         return "User-agent: *\n"
                "Disallow: /version\n"
+               "Disallow: /capabilities\n"
                "Disallow: /inspect\n"
                "Disallow: /dashboard\n"
                "Disallow: /v\n";

--- a/tests/compatibility_security_baseline.py
+++ b/tests/compatibility_security_baseline.py
@@ -1384,6 +1384,80 @@ def request(
         )
 
 
+def capabilities_endpoint_baseline(base_url: str) -> None:
+    status, body, headers = request(base_url, "/capabilities")
+    if status != 200:
+        raise AssertionError(f"capabilities endpoint failed: HTTP {status}")
+    try:
+        payload = json.loads(body)
+    except (TypeError, ValueError) as error:
+        raise AssertionError("capabilities endpoint did not return JSON") from error
+
+    if payload.get("schema_version") != 1:
+        raise AssertionError("capabilities schema version changed unexpectedly")
+    backend = payload.get("backend", {})
+    if backend.get("family") != "SubConverter-Extended":
+        raise AssertionError(f"unexpected capabilities backend: {backend!r}")
+    if not backend.get("version"):
+        raise AssertionError("capabilities endpoint omitted the backend version")
+
+    targets = [item.get("name") for item in payload.get("targets", [])]
+    expected_targets = [
+        "auto",
+        "clash",
+        "clashr",
+        "surge",
+        "quan",
+        "quanx",
+        "loon",
+        "surfboard",
+        "stash",
+        "mellow",
+        "singbox",
+        "ss",
+        "ssd",
+        "ssr",
+        "sssub",
+        "v2ray",
+        "v2rayn",
+        "v2rayng",
+        "shadowrocket",
+        "trojan",
+        "vless",
+        "hysteria2",
+        "mixed",
+    ]
+    if targets != expected_targets:
+        raise AssertionError(f"capabilities target drift: {targets!r}")
+
+    parameters = payload.get("query_parameters", {})
+    if parameters.get("forced") != {"new_name": True}:
+        raise AssertionError("capabilities did not expose the forced new_name value")
+    ignored = set(parameters.get("ignored", []))
+    if not {"groups", "ruleset", "filter_script", "token"}.issubset(ignored):
+        raise AssertionError(f"capabilities ignored parameters are incomplete: {ignored!r}")
+    constraints = parameters.get("target_constraints", {})
+    if constraints.get("provider_headers") != ["clash", "stash"]:
+        raise AssertionError("provider_headers target constraint drifted")
+    if constraints.get("provider_proxy_direct") != ["clash", "clashr"]:
+        raise AssertionError("provider_proxy_direct target constraint drifted")
+
+    modifiers = {item.get("name"): item for item in payload.get("source_modifiers", [])}
+    if set(modifiers) != {"tag", "provider", "interval", "proxy_direct"}:
+        raise AssertionError(f"source modifier capability drift: {modifiers!r}")
+    if modifiers["proxy_direct"].get("targets") != ["clash", "clashr"]:
+        raise AssertionError("proxy_direct source modifier target drifted")
+
+    if "application/json" not in headers.get("content-type", "").lower():
+        raise AssertionError("capabilities endpoint has the wrong content type")
+    if "no-store" not in headers.get("cache-control", "").lower():
+        raise AssertionError("capabilities endpoint is cacheable")
+    if headers.get("x-content-type-options", "").lower() != "nosniff":
+        raise AssertionError("capabilities endpoint omitted nosniff")
+    if headers.get("access-control-allow-origin") != "*":
+        raise AssertionError("capabilities endpoint is not available to browser clients")
+
+
 def assert_vary_header(
     headers: dict[str, str], field: str, context: str
 ) -> None:
@@ -13524,6 +13598,7 @@ def main() -> int:
         with running_service(
             binary, log_capture=wireguard_outbound_logs
         ) as base_url:
+            capabilities_endpoint_baseline(base_url)
             conversion_baselines(base_url, fixture_base, args.update_golden)
             local_group_matcher_baseline(base_url)
             singbox_modern_full_profile_baseline(


### PR DESCRIPTION
## Summary

- add a read-only `/capabilities` JSON contract derived from the actual target descriptor table
- expose recognized, ignored, internal, forced, and target-constrained request parameters
- expose SCE source modifier scopes for compatible frontends
- prevent indexing and caching while retaining browser CORS access

## Validation

- UCRT64 Release build
- CTest 27/27, including Beast and cpp-httplib compatibility/security baselines
- `/capabilities` schema, target order, parameter constraints, cache headers, nosniff, and CORS regression coverage